### PR TITLE
Added option to exclude domains from due date sync

### DIFF
--- a/modules/registrars/openprovider/Library/DomainSync.php
+++ b/modules/registrars/openprovider/Library/DomainSync.php
@@ -124,7 +124,7 @@ class DomainSync
     public function process_domains()
     {
         $this->OpenProvider = new OpenProvider;
-		$excludedDomains = include("excludedDomains.php");
+        $excludedDomains = include("excludedDomains.php");
 
         foreach($this->domains as $domain)
         {
@@ -137,10 +137,10 @@ class DomainSync
                 $this->op_domain_obj 	= $this->OpenProvider->domain($domain->domain);
                 $this->op_domain   		= $this->OpenProvider->api->retrieveDomainRequest($this->op_domain_obj);
 				
-				if (!in_array($domain->domain, $excludedDomains)) {
-					// Set the expire and due date -> openprovider is leading
-					$this->process_expiry_and_due_date();
-				}
+                if (!in_array($domain->domain, $excludedDomains)) {
+                    // Set the expire and due date -> openprovider is leading
+                    $this->process_expiry_and_due_date();
+                }
 
                 // Active or pending? -> openprovider is leading
                 $this->process_domain_status();

--- a/modules/registrars/openprovider/Library/DomainSync.php
+++ b/modules/registrars/openprovider/Library/DomainSync.php
@@ -7,7 +7,6 @@ use OpenProvider\WhmcsHelpers\Activity;
 use OpenProvider\WhmcsHelpers\General;
 use OpenProvider\WhmcsHelpers\Registrar;
 use OpenProvider\WhmcsHelpers\DomainSync as helper_DomainSync;
-
 /**
  * Helper to synchronize the domain info.
  * OpenProvider Registrar module
@@ -125,6 +124,7 @@ class DomainSync
     public function process_domains()
     {
         $this->OpenProvider = new OpenProvider;
+		$excludedDomains = include("excludedDomains.php");
 
         foreach($this->domains as $domain)
         {
@@ -136,9 +136,11 @@ class DomainSync
                 $this->domain 			= $domain;
                 $this->op_domain_obj 	= $this->OpenProvider->domain($domain->domain);
                 $this->op_domain   		= $this->OpenProvider->api->retrieveDomainRequest($this->op_domain_obj);
-
-                // Set the expire and due date -> openprovider is leading
-                $this->process_expiry_and_due_date();
+				
+				if (!in_array($domain->domain, $excludedDomains)) {
+					// Set the expire and due date -> openprovider is leading
+					$this->process_expiry_and_due_date();
+				}
 
                 // Active or pending? -> openprovider is leading
                 $this->process_domain_status();

--- a/modules/registrars/openprovider/Library/excludedDomains.php
+++ b/modules/registrars/openprovider/Library/excludedDomains.php
@@ -1,0 +1,7 @@
+<?php
+return array(
+	"domain1.example",
+	"domain2.example",
+	"domain3.example"
+);
+?>


### PR DESCRIPTION
This adds a function to allow users to exclude domains from the due/expiry date sync.
This will, by default, not impact any domains