### PR TITLE
Introducing a single request cache. Resolves #246

### DIFF
--- a/modules/registrars/openprovider/Controllers/System/ConfigController.php
+++ b/modules/registrars/openprovider/Controllers/System/ConfigController.php
@@ -7,6 +7,7 @@ use OpenProvider\API\APIConfig;
 use OpenProvider\API\ApiInterface;
 use OpenProvider\API\ResponseInterface;
 use OpenProvider\WhmcsRegistrar\enums\OpenproviderErrorType;
+use OpenProvider\WhmcsRegistrar\helpers\Cache;
 use OpenProvider\WhmcsRegistrar\src\Configuration;
 use Symfony\Component\HttpFoundation\Session\Session;
 use WeDevelopCoffee\wPower\Controllers\BaseController;
@@ -227,6 +228,10 @@ class ConfigController extends BaseController
      */
     private function checkRequest(): ResponseInterface
     {
+        if(Cache::has('op_check_request')) {
+            return Cache::get('op_check_request');
+        }
+
         $args = [];
         if ($this->apiClient->getConfiguration()->getHost() == Configuration::get('api_url')) {
             $commandToCheckAccess = 'searchPromoMessageRequest';
@@ -235,6 +240,7 @@ class ConfigController extends BaseController
             $args['limit'] = 1;
         }
 
-        return $this->apiClient->call($commandToCheckAccess, $args);
+        $data = $this->apiClient->call($commandToCheckAccess, $args);
+        return Cache::set('op_check_request', $data);
     }
 }

--- a/modules/registrars/openprovider/helpers/Cache.php
+++ b/modules/registrars/openprovider/helpers/Cache.php
@@ -1,0 +1,56 @@
+<?php
+
+
+namespace OpenProvider\WhmcsRegistrar\helpers;
+
+/**
+ * Caches data for one request.
+ */
+class Cache
+{
+    /**
+     * @var array Cached items
+     */
+    protected static $cache;
+
+    /**
+     * Set a cached item.
+     * @param $key
+     * @param $value
+     * @return mixed
+     */
+    public static function set($key, $value)
+    {
+        self::$cache[$key] = $value;
+        return $value;
+    }
+
+    /**
+     * Check if a cached item exitss.
+     * @param $key
+     * @return mixed
+     */
+    public static function has($key)
+    {
+        return isset(self::$cache[$key]);
+    }
+
+    /**
+     * Get the cached item.
+     * @param $key
+     * @return mixed
+     */
+    public static function get($key)
+    {
+        return self::$cache[$key];
+    }
+
+    /**
+     * Get all cached items.
+     * @return array
+     */
+    public static function all()
+    {
+        return self::$cache;
+    }
+}


### PR DESCRIPTION
When browsing through the domain list as an admin, many Openprovider instances are launched. Each instance makes a request to Openprovider to validate the token. This cache reduces the amount of requests to just once per page load.

- Introduces single page load cache.
- Implements cache in the ConfigController.php -> checkRequest()