### PR TITLE
Updated curly braces to suit the php 8.1 requirements

### DIFF
--- a/modules/registrars/openprovider/classes/idna_convert.class.php
+++ b/modules/registrars/openprovider/classes/idna_convert.class.php
@@ -422,7 +422,7 @@ if (!class_exists('idna_convert')) {
             $delim_pos = strrpos($encoded, '-');
             if ($delim_pos > self::byteLength($this->_punycode_prefix)) {
                 for ($k = self::byteLength($this->_punycode_prefix); $k < $delim_pos; ++$k) {
-                    $decoded[] = ord($encoded{$k});
+                    $decoded[] = ord($encoded[$k]);
                 }
             }
             $deco_len = count($decoded);
@@ -436,7 +436,7 @@ if (!class_exists('idna_convert')) {
 
             for ($enco_idx = ($delim_pos) ? ($delim_pos + 1) : 0; $enco_idx < $enco_len; ++$deco_len) {
                 for ($old_idx = $idx, $w = 1, $k = $this->_base; 1; $k += $this->_base) {
-                    $digit = $this->_decode_digit($encoded{$enco_idx++});
+                    $digit = $this->_decode_digit($encoded[$enco_idx++]);
                     $idx += $digit * $w;
                     $t = ($k <= $bias) ? $this->_tmin :
                             (($k >= $bias + $this->_tmax) ? $this->_tmax : ($k - $bias));
@@ -847,7 +847,7 @@ if (!class_exists('idna_convert')) {
             $mode = 'next';
             $test = 'none';
             for ($k = 0; $k < $inp_len; ++$k) {
-                $v = ord($input{$k}); // Extract byte from input string
+                $v = ord($input[$k]); // Extract byte from input string
                 if ($v < 128) { // We found an ASCII char - put into stirng as is
                     $output[$out_len] = $v;
                     ++$out_len;
@@ -977,7 +977,7 @@ if (!class_exists('idna_convert')) {
                     $out_len++;
                     $output[$out_len] = 0;
                 }
-                $output[$out_len] += ord($input{$i}) << (8 * (3 - ($i % 4) ) );
+                $output[$out_len] += ord($input[$i]) << (8 * (3 - ($i % 4) ) );
             }
             return $output;
         }


### PR DESCRIPTION
at four spots this class was still using the curly braces {}. These are now changed to [] to suit the php 8.1 requirements. Updated class does not break the WHMCS 8.6 update anymore.