### PR TITLE
Type Countable Array in php 8.1 not valid coded

### DIFF
--- a/modules/registrars/openprovider/OpenProvider/API/CustomerTags.php
+++ b/modules/registrars/openprovider/OpenProvider/API/CustomerTags.php
@@ -29,7 +29,7 @@ class CustomerTags extends \OpenProvider\API\AutoloadConstructor
      */
     public function setTags($tags = array())
     {
-        if (!count($tags) || empty($tags))
+        if (!count((array)$tags) || empty($tags))
             $this->tags = [];
 
         $this->tags = array_map(function ($tag) {
@@ -37,7 +37,7 @@ class CustomerTags extends \OpenProvider\API\AutoloadConstructor
                 'key'   => 'customer',
                 'value' => $tag,
             ];
-        }, $tags);
+        }, (array)$tags);
     }
 
     /**


### PR DESCRIPTION
count(): Argument #1 ($var) must be of type Countable|array, null given. Adjustments made to comply with php 8.1 coding.
Without this no domains can be registered.