### PR TITLE
Fix for error thrown by php 8.1 in whmcs 8.6.1

### DIFF
--- a/modules/addons/openprovider/resources/views/scheduled_domain_transfer/index.tpl
+++ b/modules/addons/openprovider/resources/views/scheduled_domain_transfer/index.tpl
@@ -11,7 +11,7 @@
         {/if}
 
 
-        {if count($scheduled_domain_transfers) == 0 }
+        {if $scheduled_domain_transfers == null or count($scheduled_domain_transfers) == 0}
             {$LANG.no_scheduled_domain_transfers}
         {else}
             <div class="pull-right" style="margin-bottom:10px;">


### PR DESCRIPTION
This template does not work in php 8.1 on whmcs 8.6.1.
Its a simple fix, check if the returned value is null before attempting to count it.