### PR TITLE
Fix bug in domain search in WHMCS client area

### DIFF
--- a/modules/registrars/openprovider/Controllers/System/DomainSuggestionsController.php
+++ b/modules/registrars/openprovider/Controllers/System/DomainSuggestionsController.php
@@ -60,7 +60,7 @@ class DomainSuggestionsController extends BaseController
 
         $args['sensitive'] = isset($suggestionSettings['sensitive']) && $suggestionSettings['sensitive'] == 'on';
 
-        if (isset($suggestionSettings['suggestTlds']) && !empty($suggestionSettings['suggestTlds'])) {
+        if (!empty($suggestionSettings['suggestTlds'])) {
             $args['tlds'] = array_map(function ($tld) {
                 return mb_substr($tld, 1);
             }, explode(',', $suggestionSettings['suggestTlds']));

--- a/modules/registrars/openprovider/Controllers/System/DomainSuggestionsController.php
+++ b/modules/registrars/openprovider/Controllers/System/DomainSuggestionsController.php
@@ -60,7 +60,7 @@ class DomainSuggestionsController extends BaseController
 
         $args['sensitive'] = isset($suggestionSettings['sensitive']) && $suggestionSettings['sensitive'] == 'on';
 
-        if (isset($suggestionSettings['suggestTlds']) && count($suggestionSettings['suggestTlds']) > 0) {
+        if (isset($suggestionSettings['suggestTlds']) && !empty($suggestionSettings['suggestTlds'])) {
             $args['tlds'] = array_map(function ($tld) {
                 return mb_substr($tld, 1);
             }, explode(',', $suggestionSettings['suggestTlds']));
@@ -81,7 +81,7 @@ class DomainSuggestionsController extends BaseController
             $status = SearchResult::STATUS_NOT_REGISTERED;
             $searchResult->setStatus($status);
 
-            if($params['OpenproviderPremium'] == true && isset($item['premium'])) {
+            if ($params['OpenproviderPremium'] == true && isset($item['premium'])) {
                 $premiumPriceArgs = [];
                 $searchResult->setPremiumDomain(true);
 


### PR DESCRIPTION
'suggestTlds' in 'suggestionSettings' has a string value. To check whether the value is empty code used the count method which does not work with strings.

Changed the checker with empty method where we can pass a string value to it to check whether .suggestTlds. is empty.