### PR TITLE
[Fixed] Cron does not mark transferred-out domains as canceled

### DIFF
--- a/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
+++ b/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
@@ -5,6 +5,7 @@ namespace OpenProvider\API;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use WeDevelopCoffee\wPower\Models\Domain as DomainModel;
+use OpenProvider\WhmcsHelpers\Domain as DomainWHMCS;
 
 class ApiHelper
 {
@@ -41,10 +42,26 @@ class ApiHelper
         ];
 
         $args = array_merge($args, $additionalArgs);
+        $domainName = $domain->name . "." . $domain->extension;
         $domain = $this->buildResponse($this->apiClient->call('searchDomainRequest', $args));
 
         if (!is_null($domain['results'][0])) {
             return $domain['results'][0];
+        }
+
+        // Update status in WHMCS DB as Cancelled if domain does not exist in given OP account
+        $domainId = DomainWHMCS::getDomainId($domainName);
+        if($domainId >= 0)
+        {
+            $command = 'UpdateClientDomain';
+            $postData = array(
+                'domainid' => $domainId,
+                'status' => 'Cancelled',
+            );
+            //$adminUsername = 'ADMIN_USERNAME'; // Optional for WHMCS 7.2 and later
+
+            $results = localAPI($command, $postData);
+            logModuleCall('WHMCS internal', $command, "{'domainid':$domainId,'status':'Cancelled'}",$results, null, null);
         }
 
         throw new \Exception('Domain does not exist in Openprovider!');

--- a/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
+++ b/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
@@ -51,14 +51,13 @@ class ApiHelper
 
         // Update status in WHMCS DB as Cancelled if domain does not exist in given OP account
         $domainId = DomainWHMCS::getDomainId($domainName);
-        if($domainId !== null)
+        if($domainId != null)
         {
             $command = 'UpdateClientDomain';
             $postData = array(
                 'domainid' => $domainId,
                 'status' => 'Cancelled',
             );
-            //$adminUsername = 'ADMIN_USERNAME'; // Optional for WHMCS 7.2 and later
 
             $results = localAPI($command, $postData);
             logModuleCall('WHMCS internal', $command, "{'domainid':$domainId,'status':'Cancelled'}",$results, null, null);

--- a/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
+++ b/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
@@ -51,7 +51,7 @@ class ApiHelper
 
         // Update status in WHMCS DB as Cancelled if domain does not exist in given OP account
         $domainId = DomainWHMCS::getDomainId($domainName);
-        if($domainId >= 0)
+        if($domainId !== null)
         {
             $command = 'UpdateClientDomain';
             $postData = array(

--- a/modules/registrars/openprovider/OpenProvider/WhmcsHelpers/Domain.php
+++ b/modules/registrars/openprovider/OpenProvider/WhmcsHelpers/Domain.php
@@ -52,5 +52,22 @@ class Domain
 		}
 	}
 
+	public static function getDomainId($domainName)
+	{
+		try {
+			$domain = Capsule::table('tbldomains')
+				->where('domain', $domainName)
+				->first();
+
+			if ($domain) {
+				return $domain->id;
+			}
+			return -1;
+		} catch (\Exception $e) {
+			logModuleCall("WHMCS DB", 'get_domain_id', "{domain: $domainName}", $e->getMessage(), $domainName);
+			return -1;
+		}
+	}
+
 
 } // END class Domain

--- a/modules/registrars/openprovider/OpenProvider/WhmcsHelpers/Domain.php
+++ b/modules/registrars/openprovider/OpenProvider/WhmcsHelpers/Domain.php
@@ -63,8 +63,7 @@ class Domain
 				return $domain->id;
 			}
 			
-			return null; 
-			
+			return null;			
 		} catch (\Exception $e) {
 			logModuleCall("WHMCS DB", 'get_domain_id', "{domain: $domainName}", $e->getMessage(), $domainName);
 			

--- a/modules/registrars/openprovider/OpenProvider/WhmcsHelpers/Domain.php
+++ b/modules/registrars/openprovider/OpenProvider/WhmcsHelpers/Domain.php
@@ -62,10 +62,13 @@ class Domain
 			if ($domain) {
 				return $domain->id;
 			}
-			return -1;
+			
+			return null; 
+			
 		} catch (\Exception $e) {
 			logModuleCall("WHMCS DB", 'get_domain_id', "{domain: $domainName}", $e->getMessage(), $domainName);
-			return -1;
+			
+			return null; 
 		}
 	}
 


### PR DESCRIPTION
A method to mark a domain as "canceled" if that domain is no longer available for that reseller account.
WHMCS native cron can be also used to sync this domain status.