### PR TITLE
'wedevelopcoffee' module seems to cause some PHP 8 errors

### DIFF
--- a/modules/registrars/openprovider/vendor/wedevelopcoffee/wpower/src/Domain/AdditionalFields.php
+++ b/modules/registrars/openprovider/vendor/wedevelopcoffee/wpower/src/Domain/AdditionalFields.php
@@ -92,6 +92,11 @@ class AdditionalFields
                     // Disable the additional fields.
                     foreach($this->distAdditionalFields[$tld] as $whmcsField)
                     {
+                        if (!is_array($whmcsField)) {
+                            $name = $whmcsField;
+                            $whmcsField = array();
+                            $whmcsField['Name'] = $name;
+                        }
                         // Only remove fields that are not in the Registrars field.
                         if(!isset($tmpRegistrarFields[$whmcsField['Name']]))
                         {


### PR DESCRIPTION
There is case where whmcsField variable contains a string instead of an array, if in that case we need to check for the variable for an array and reassign an array with the string value in it.