### PR TITLE
Fix for domain renewal error

### DIFF
--- a/modules/addons/openprovider/Controllers/Hooks/RenewHookController.php
+++ b/modules/addons/openprovider/Controllers/Hooks/RenewHookController.php
@@ -66,7 +66,10 @@ class RenewHookController extends BasePermissionController
 
         if ($this->checkIsNotOpenprovider($domain) == false) // It is an openprovider domain. Skip this one.
         {
-            return true;
+            //return true;
+            return array(
+                'abortWithSuccess' => true,
+            );
         }
 
         // Check if the domain is scheduled for a transfer.
@@ -92,7 +95,10 @@ class RenewHookController extends BasePermissionController
             try {
                 $openprovider_domain = $this->openProvider->api->modifyScheduledTransferDate($openprovider_api_domain, date("Y-m-d H:i:s"));
             } catch (\Exception $ex) {
-                return false;
+                // return false;
+                return array(
+                    'abortWithError' => $ex->getMessage(),
+                );
             }
 
             return array (
@@ -100,7 +106,10 @@ class RenewHookController extends BasePermissionController
             );
         }
 
-        return false;
+        // return false;
+        return array(
+            'abortWithError' => 'The domain is not scheduled for a transfer.',
+        );
     }
 
     /**

--- a/modules/addons/openprovider/Controllers/Hooks/RenewHookController.php
+++ b/modules/addons/openprovider/Controllers/Hooks/RenewHookController.php
@@ -68,7 +68,7 @@ class RenewHookController extends BasePermissionController
         {
             //return true;
             return array(
-                'abortWithSuccess' => true,
+                'success' => true,
             );
         }
 
@@ -108,7 +108,7 @@ class RenewHookController extends BasePermissionController
 
         // return false;
         return array(
-            'abortWithError' => 'The domain is not scheduled for a transfer.',
+            'success' => true,
         );
     }
 


### PR DESCRIPTION
Fix for domain renewal error due to passing bool instead of an formatted array.