### PR TITLE
Fixed Openprovider balance widget closing issue.

### DIFF
--- a/modules/registrars/openprovider/Controllers/Hooks/AdminWidgetController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/AdminWidgetController.php
@@ -14,6 +14,8 @@ use OpenProvider\WhmcsRegistrar\Controllers\Hooks\Widgets\BalanceWidget;
 
 class AdminWidgetController
 {
+    const BALANCE_WIDGET_FILE = '/BalanceWidget.php';
+
     /**
      * @var ApiHelper
      */
@@ -31,6 +33,21 @@ class AdminWidgetController
 
     public function showBalance ($vars)
     {
-        return new BalanceWidget($this->apiHelper, $this->xmlApiAdapter);
+        $this->copyCustomWidgets();
+    }
+
+    private function copyCustomWidgets()
+    {
+        $destinationLocation = $GLOBALS['whmcsAppConfig']->getRootDir() . '/modules/widgets' . self::BALANCE_WIDGET_FILE;
+        $sourceLocation = $GLOBALS['whmcsAppConfig']->getRootDir() . '/modules/registrars/openprovider/Controllers/Hooks/Widgets' . self::BALANCE_WIDGET_FILE;
+        if (
+            !file_exists($destinationLocation) ||
+            empty(file_get_contents($destinationLocation))
+        ) {
+            // Attempt to copy BalanceWidget.php file into the modules/widgets folder
+            if (!copy($sourceLocation, $destinationLocation)) {
+                logModuleCall('openprovider', 'copybalancewidgetfile', null, "Balance Widget error! Failed to add BalanceWidget.php to /modules/widgets directory. Please manually upload the contents of '<Module directory>/registrars/openprovider/Controllers/Hooks/Widgets' to the /modules/widget folder of your WHMCS folder i.e. '<your WHMCS directory>/modules/widgets'", null, null);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixed BalanceWidget closing issue in OP module.
Create a copying function for BalanceWidget in OP module.`(from OP-WHMCS7/modules/registrars/openprovider/Controllers/Hooks/Widgets/BalanceWidget.php to app/whmcs/modules/widgets/BalanceWidget.php)`
Added meaning full error messages when not having OP module.