### PR TITLE
Peformance boost: Optimize configuration loading and credential checks

### DIFF
--- a/modules/registrars/openprovider/Controllers/System/ConfigController.php
+++ b/modules/registrars/openprovider/Controllers/System/ConfigController.php
@@ -67,12 +67,17 @@ class ConfigController extends BaseController
         ) {
             Capsule::table('reseller_tokens')->where('username', $oldParams['Username'])->delete();
         }
+
         // If we have some login data, let's try to login.
-        $areCredentialsExist = isset($params['Password']) &&
-            isset($params['Username']) &&
-            !empty($params['Password']) &&
-            !empty($params['Username']);
-        if ($areCredentialsExist) {
+        if ( isset($params['Password'])
+            && isset($params['Username'])
+            && !empty($params['Password'])
+            && !empty($params['Username'])
+            && isset($_GET['action'])
+            && $_GET['action'] == 'save'
+            && isset($_GET['module'])
+            && $_GET['module'] == 'openprovider'
+        ) {
             $configarray = $this->checkCredentials($configarray, $params);
         }
 
@@ -213,7 +218,7 @@ class ConfigController extends BaseController
         $this->apiClient->getConfiguration()->setHost($differentHost);
 
         if (!Cache::has('op_auth_generate')) {
-            
+
             $reply = $this->apiClient->call('generateAuthTokenRequest', [
                 'username' => $params['Username'],
                 'password' => $params['Password']

--- a/modules/registrars/openprovider/openprovider.php
+++ b/modules/registrars/openprovider/openprovider.php
@@ -36,11 +36,17 @@ spl_autoload_register(function ($className) {
  * @param array $params
  * @return mixed
  */
-function openprovider_getConfigArray($params = array())
+function openprovider_getConfigArray(array $params = [])
 {
-    return openprovider_registrar_launch_decorator('config', $params);
-}
+    static $openprovider_config = [];
 
+    if (!empty($openprovider_config)) {
+        return $openprovider_config;
+    }
+
+    $openprovider_config = openprovider_registrar_launch_decorator('config', $params);
+    return $openprovider_config;
+}
 
 /**
  * Register the domain.
@@ -346,7 +352,7 @@ function openprovider_config_validate($params)
         $baseUrl = Configuration::get('api_url_cte');
     }
 
-    $url = "{$baseUrl}{$resourcePath}"; 
+    $url = "{$baseUrl}{$resourcePath}";
 
     $data = array(
         "username" => $username,


### PR DESCRIPTION
Modified `openprovider_getConfigArray` to use static caching for configuration and refined the credential check logic in `ConfigController` to include additional parameters such as action and module. These changes aim to improve performance and ensure the proper execution of credential verification, but only upon saving in WHMCS.

Reduced admin/clientssummary.php?userid=xxx from 11 seconds to 1.34 seconds.