### PR TITLE
Intgrtns 264 whmcs .es transfer auth code

### DIFF
--- a/modules/registrars/openprovider/Controllers/System/EppController.php
+++ b/modules/registrars/openprovider/Controllers/System/EppController.php
@@ -49,15 +49,24 @@ class EppController extends BaseController
             'extension' => $params['tld']
         ]);
 
+        $eppCode = "";
+
         try {
             $domainOp = $this->apiHelper->getDomain($domain);
+
+            $eppCode = $domainOp['authCode'];
+
+            if ($eppCode == "") {
+                $id = $domainOp['id'];
+                $eppCode = $this->apiHelper->getEppCode($id);
+            }
         } catch (\Exception $e) {
             return [
                 'error' => $e->getMessage()
             ];
         }
 
-        $values["eppcode"] = $domainOp['authCode'] ?? '';
+        $values["eppcode"] = $eppCode;
 
         return $values;
     }

--- a/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
+++ b/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
@@ -52,6 +52,30 @@ class ApiHelper
 
     /**
      * @param int $id
+     * @return string
+     * @throws \Exception
+     */
+    public function getEPPCode(int $id): string
+    {
+        $args = [
+            'id'     => $id,
+        ];
+
+        $result = $this->buildResponse($this->apiClient->call('getEPPCodeRequest', $args));
+
+        if (isset($result['authCode'])) {
+            return $result['authCode'];
+        }
+
+        if (isset($result['message']) && $result['message'] != "") {
+            throw new \Exception($result['message']);
+        }
+
+        throw new \Exception('An unknown error occurred.');
+    }
+
+    /**
+     * @param int $id
      * @param array $data
      * @return array
      * @throws \Exception

--- a/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
+++ b/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
@@ -61,17 +61,21 @@ class ApiHelper
             'id'     => $id,
         ];
 
-        $result = $this->buildResponse($this->apiClient->call('getEPPCodeRequest', $args));
+        $result = '';
 
-        if (isset($result['authCode'])) {
-            return $result['authCode'];
+        try {
+            $result = $this->buildResponse($this->apiClient->call('getEPPCodeRequest', $args));
+
+            if (isset($result['authCode'])) {
+                return $result['authCode'];
+            }
+
+            if (isset($result['message']) && $result['message'] != "") {
+                throw new \Exception($result['message']);
+            }
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage(), $e->getCode());
         }
-
-        if (isset($result['message']) && $result['message'] != "") {
-            throw new \Exception($result['message']);
-        }
-
-        throw new \Exception('An unknown error occurred.');
     }
 
     /**

--- a/modules/registrars/openprovider/OpenProvider/API/CommandMapping.php
+++ b/modules/registrars/openprovider/OpenProvider/API/CommandMapping.php
@@ -14,6 +14,7 @@ use Openprovider\Api\Rest\Client\Person\Api\EmailVerificationApi;
 use Openprovider\Api\Rest\Client\Person\Api\PromoMessageServiceApi;
 use Openprovider\Api\Rest\Client\Person\Api\ResellerServiceApi;
 use Openprovider\Api\Rest\Client\Tld\Api\TldServiceApi;
+use Openprovider\Api\Rest\Client\Domain\Api\AuthCodeApi;
 
 class CommandMapping
 {
@@ -134,7 +135,7 @@ class CommandMapping
         'searchNsRequest' => [
             self::COMMAND_MAP_METHOD => 'getNameserver',
             self::COMMAND_MAP_CLASS => NameserverServiceApi::class,
-        ],      
+        ],
         'listNsRequest' => [
             self::COMMAND_MAP_METHOD => 'listNameservers',
             self::COMMAND_MAP_CLASS => NameserverServiceApi::class,
@@ -168,6 +169,12 @@ class CommandMapping
         'searchPromoMessageRequest' => [
             self::COMMAND_MAP_METHOD => 'listPromoMessages',
             self::COMMAND_MAP_CLASS => PromoMessageServiceApi::class
+        ],
+
+        // EPP Code
+        'getEPPCodeRequest' => [
+            self::COMMAND_MAP_METHOD => 'getAuthCode',
+            self::COMMAND_MAP_CLASS => AuthCodeApi::class
         ]
     ];
 


### PR DESCRIPTION
Implement getEPPCode method and call getAuthCode API to get epp code for domains that do not return epp code with search domain request.