### PR TITLE
INTGRTNS-256 WHMCS feature request-open new dns manager in a new tab

### DIFF
--- a/modules/registrars/openprovider/Controllers/Hooks/DnsAuthController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/DnsAuthController.php
@@ -15,17 +15,28 @@ class DnsAuthController {
     public function redirectDnsManagementPage ($params)
     {
         if($url = DNS::getDnsUrlOrFail($params['domainid']))
-        {            
-            // Perform redirect.        
-            //header("Location: " . $url);
-
+        {
             $urlOne = $_SERVER['HTTP_REFERER'];
             $url_decoded = html_entity_decode($urlOne);
 
-            // Perform open in new tab.
+        
+            // JavaScript confirm dialog
             echo '<script type="text/javascript">
-                    window.open("' . $url . '");
-                    window.location.href = "' . $url_decoded . '";
+                    document.addEventListener("DOMContentLoaded", function() {
+                        var userConfirmed = confirm("Do you want to open in New Tab?");
+                        if (userConfirmed) {
+                            var newWindow = window.open("' . $url . '", "_blank"); // Open OP DNS management page in a new tab
+                            if (newWindow) {
+                                window.location.href = "' . $url_decoded . '"; // Redirect to previous page
+                                newWindow.focus(); // Focus on the new tab
+                            } else {
+                                alert("New tab opening blocked! Please allow it for this site.");
+                                window.location.href = "' . $url . '"; // Redirect to OP DNS management page
+                            }
+                        } else {
+                            window.location.href = "' . $url . '"; // Redirect to OP DNS management page
+                        }
+                    });
                   </script>';
             exit;
         }

--- a/modules/registrars/openprovider/Controllers/Hooks/DnsAuthController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/DnsAuthController.php
@@ -15,9 +15,18 @@ class DnsAuthController {
     public function redirectDnsManagementPage ($params)
     {
         if($url = DNS::getDnsUrlOrFail($params['domainid']))
-        {
-            // Perform redirect.
-            header("Location: " . $url);
+        {            
+            // Perform redirect.        
+            //header("Location: " . $url);
+
+            $urlOne = $_SERVER['HTTP_REFERER'];
+            $url_decoded = html_entity_decode($urlOne);
+
+            // Perform open in new tab.
+            echo '<script type="text/javascript">
+                    window.open("' . $url . '");
+                    window.location.href = "' . $url_decoded . '";
+                  </script>';
             exit;
         }
     }


### PR DESCRIPTION
### Description

To use the Openprovider **Single Domain DNS panel** page, the user needs to enable `"useNewDnsManagerFeature=true"` in the _**advanced-module-configurations.php**_ file.
Previously it was open in the same tab (redirect to Single Domain DNS panel page). Now it is able to open the Single Domain DNS panel page in new tab instead of redirecting.