### PR TITLE
INTGRTNS-261 DNSSEC management section is activated by default when registering a domain

### DIFF
--- a/modules/registrars/openprovider/Controllers/Hooks/ClientAreaPrimarySidebarController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ClientAreaPrimarySidebarController.php
@@ -84,6 +84,10 @@ jQuery( document ).ready(function() {
                 ->where('id', $domainId)
                 ->select('status', 'dnsmanagement', 'domain')
                 ->first();
+            
+            if ($isDomainEnabled->dnsmanagement != 1){
+                return;
+            }
 
             $domain = DomainFullNameToDomainObject::convert($isDomainEnabled->domain);
             try {


### PR DESCRIPTION
### Description

Fixed issue.
Previously, the DNSSEC management section is activated by default when registering a domain. Now it is not activated by default and needs to enable `DNS management` to activate DNSSEC management section.