### PR TITLE
Fix error with Improper To-Do list creation for other registrar domains

### DIFF
--- a/modules/addons/openprovider/Controllers/Hooks/RenewHookController.php
+++ b/modules/addons/openprovider/Controllers/Hooks/RenewHookController.php
@@ -122,6 +122,35 @@ class RenewHookController extends BasePermissionController
 
     /**
      * Check if a domain transfer is scheduled with Openprovider.
+     * @param $domain
+     * @return boolean
+     */
+    protected function checkOnlyScheduledTransferAtOpenprovider($domain)
+    {
+        // First, find the domain in the local list.
+        try {
+            $scheduled_domain_transfer = $this->scheduledDomainTransfer->where(
+                'domain',
+                $domain->domain
+            )->firstOrFail();
+
+            // SCH means scheduled transfer.
+            if ($scheduled_domain_transfer->status == 'SCH') {
+                return true;
+            } else // The domain does exist with Openprovider but is not scheduled for a transfer.
+            {
+                return false;
+            }
+        } catch (ModelNotFoundException $e) {
+            // Nothing was found.
+            return false;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if a domain transfer is scheduled with Openprovider.
      * If so, record the renewal and prevent that the renewal is
      * being executed at the original provider.
      * @param $domain
@@ -218,8 +247,13 @@ class RenewHookController extends BasePermissionController
                 // There was no scheduled transfer tracked. This is all good.
             }
         } elseif ($renewal_action == 'enable') {
-            $this->add_todo('The autorenewal for ' . $domain->domain . ' has been enabled. Reschedule the transfer with Openprovider.',
+            $isScheduledTransfer = $this->checkOnlyScheduledTransferAtOpenprovider($domain);
+            if ($isScheduledTransfer) {
+                $this->add_todo(
+                    'The autorenewal for ' . $domain->domain . ' has been enabled. Reschedule the transfer with Openprovider.',
                 'Reschedule the transfer in case this domain was supposed to get transferred.');
+            }
+            
         }
 
         return true;


### PR DESCRIPTION
Previously it created todos' for all non-op domains with renewal_action == 'enable'.

Fix:-
When the domain is non-op with renewal_action == 'enable',
Only domains with **Scheduled Transfers with OP** needs to **create the todos**. 