### PR TITLE
Automatically display additional fields in cart

### DIFF
--- a/modules/registrars/openprovider/openprovider.php
+++ b/modules/registrars/openprovider/openprovider.php
@@ -393,3 +393,16 @@ function openprovider_registrar_launch_decorator(string $route, $params = [], $l
 
     return $launch->output($modifiedParams, $route);
 }
+
+function openprovider_AdditionalDomainFields(array $params)
+{
+    $additionalfields = openprovider_additional_fields();
+
+    if (isset($additionalfields[".{$params['tld']}"])) {
+        $values["fields"] = $additionalfields[".{$params['tld']}"];
+    } else {
+        $values["fields"] = [];
+    }
+
+    return $values;
+}


### PR DESCRIPTION
If you're using multiple registrar modules, managing additional domain fields can be messy. 
This small addition to the module will automatically generate the additional fields on the domain configuration page - no need to include them manually in /resources/domains/additionalfields.php in WHMCS.

The additional fields will only be shown if the OpenProvider module is set as Auto Register for a the TLD that is being configured.

The `$params` array parsed to `openprovider__AdditionalDomainFields()` also includes a "type" key with the values of "register" or "transfer", meaning unnecessary fields can be omitted with very little extra code. It's currently broken right now as it always returns "register", but I've already contacted WHMCS about this.