### PR TITLE
Fix error accessing admin dashboard

### DIFF
--- a/modules/registrars/openprovider/vendor/phpdocumentor/reflection-docblock/src/DocBlock/Tags/InvalidTag.php
+++ b/modules/registrars/openprovider/vendor/phpdocumentor/reflection-docblock/src/DocBlock/Tags/InvalidTag.php
@@ -86,7 +86,7 @@ final class InvalidTag implements Tag
             if (isset($trace[0]['args'])) {
                 $trace = array_map(
                     function (array $call) : array {
-                        $call['args'] = array_map([$this, 'flattenArguments'], $call['args']);
+                        $call['args'] = array_map([$this, 'flattenArguments'], $call['args'] ?? []);
 
                         return $call;
                     },


### PR DESCRIPTION
Changed to fix an exception with type error from the specific line
`TypeError: array_map(): Argument #2 ($array) must be of type array, null given`