### PR TITLE
Intgrtns 274 whmcs additionalfields.php unsetting required fields

### DIFF
--- a/modules/registrars/openprovider/configuration/additionalfields.php
+++ b/modules/registrars/openprovider/configuration/additionalfields.php
@@ -412,8 +412,26 @@ $additionaldomainfields[".sg"][] = array(
     "LangVar" => "companyRegistrationNumber",
     "Type" => "text",
     "Size" => "30",
-    "op_location" => "customerExtensionAdditionalData",
+    "op_location" => "domainAdditionalData",
     "op_name"  => "companyRegistrationNumber"
+);
+
+$additionaldomainfields[".sg"][] = array(
+    "Name" => "Singapore Personal Access ID",
+    "LangVar" => "adminSingPassId",
+    "Type" => "text",
+    "Size" => "30",
+    "op_location" => "domainAdditionalData",
+    "op_name"  => "adminSingPassId"
+);
+
+$additionaldomainfields[".sg"][] = array(
+    "Name" => "Passport Number",
+    "LangVar" => "passportNumber",
+    "Type" => "text",
+    "Size" => "30",
+    "op_location" => "customerAdditionalData",
+    "op_name"  => "passportNumber"
 );
 
 // .COM.SG

--- a/modules/registrars/openprovider/configuration/additionalfields.php
+++ b/modules/registrars/openprovider/configuration/additionalfields.php
@@ -902,13 +902,24 @@ $additionaldomainfields['.fi'][] = array(
     "op_name"  => "birthDate"
 );
 
-$additionaldomainfields['.nu'][] = array(
-    'Name' => 'Identification Number',
-    "Remove" => true,
+// .NU
+$additionaldomainfields[".nu"][] = array(
+    "Name" => "Owner type",
+    "op_dropdown_for_op_name" => "nuIdentificationNumber",
+    "LangVar" => "nuIdentificationType",
+    "Type" => "dropdown",
+    "Options" => "socialSecurityNumber|Private individual,companyRegistrationNumber|Legal Entity",
+    "Default" => "Private individual",
 );
+
 $additionaldomainfields['.nu'][] = array(
-    'Name' => 'VAT Number',
-    "Remove" => true,
+    'Name' => 'Identification number',
+    "LangVar" => "nuIdentificationNumber",
+    "Type" => "text",
+    "Size" => "30",
+    "Required" => true,
+    "op_location" => "customerAdditionalData",
+    "op_name"  => "nuIdentificationNumber" // Real name is defined by the op_dropdown_for_op_name.
 );
 
 // .PRO


### PR DESCRIPTION
Add Required Additional data fields for,

1. .SG

- According to the [KB article](https://support.openprovider.eu/hc/en-us/articles/360000734547--sg) and [investigation](https://docs.google.com/spreadsheets/d/1Nlz2olA-1VvWtqa08i4rJ-HYAUeqOIi3RnmTeo0HOmg/edit?gid=0#gid=0) 2 fields are missing and 1 has a wrong type.

2. .NU

- Adding neccessary additional fields according to the [KB article](https://support.openprovider.eu/hc/en-us/articles/360000756528--nu).