### PR TITLE
Fix for random admin logouts when using Openprovider with database sessions

### DIFF
--- a/modules/registrars/openprovider/init.php
+++ b/modules/registrars/openprovider/init.php
@@ -12,6 +12,7 @@ use OpenProvider\API\ApiV1;
 use Psr\Log\LoggerInterface;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use WeDevelopCoffee\wPower\Core\Core;
 use WeDevelopCoffee\wPower\Models\Registrar;
@@ -63,7 +64,7 @@ function openprovider_bind_required_classes($launcher)
     });
 
     $launcher->set(Session::class, function (ContainerInterface $c) {
-        return new Session();
+        return new Session(new MockArraySessionStorage());
     });
 
     $launcher->set(CamelCaseToSnakeCaseNameConverter::class, function (ContainerInterface $e) {
@@ -109,16 +110,16 @@ function openprovider_bind_required_classes($launcher)
             $client->getConfiguration()->setToken($token);
         } else {
             Capsule::table('reseller_tokens')->where('username', $params['Username'])->delete();
-            
-            if (!Cache::has('op_auth_generate')) {    
+
+            if (!Cache::has('op_auth_generate')) {
                 $reply = $client->call('generateAuthTokenRequest', [
                     'username' => $params['Username'],
                     'password' => $params['Password']
                 ]);
-    
+
                 Cache::set('op_auth_generate', $reply);
-                
-                $token = $reply->getData()['token']; 
+
+                $token = $reply->getData()['token'];
                 if ($token) {
                     Capsule::table('reseller_tokens')->insert([
                         'username' => $params['Username'],
@@ -126,7 +127,7 @@ function openprovider_bind_required_classes($launcher)
                         'expire_at' => Carbon::now()->addDays(AUTH_TOKEN_EXPIRATION_LIFE_TIME)->toDateTimeString(),
                         'created_at' => Carbon::now()->toDateTimeString()
                     ]);
-    
+
                     $session->getMetadataBag()->stampNew(SESSION_EXPIRATION_LIFE_TIME);
                     $client->getConfiguration()->setToken($token);
                 }


### PR DESCRIPTION
- Replaced "[new Session()](https://github.com/openprovider/Openprovider-WHMCS-domains/blob/038200f3aa09aa9ef40f3f69cdeaf1c5067ea7f6/modules/registrars/openprovider/init.php#L65)" with "new Session(new MockArraySessionStorage())" inside [init.php](https://github.com/openprovider/Openprovider-WHMCS-domains/blob/038200f3aa09aa9ef40f3f69cdeaf1c5067ea7f6/modules/registrars/openprovider/init.php#L51).

- By calling new Session(), it silently runs session_start(). WHMCS therefore creates a second row in tblsessions that has no admin id; on the next refresh WHMCS sees that “guest” row as the most-recent session and forces a log-out.
- By replacing the new Session() call with new Session(new MockArraySessionStorage()), logouts can be eliminated.
- A MockArraySessionStorage backend keeps all session data only in RAM for the current request. It never calls session_start(), never writes to tblsessions, and is discarded as soon as the page finishes. This avoids the extra “guest” row, so the log-outs stop.