### PR TITLE
Fix issue with handle duplicating while contact modifying

### DIFF
--- a/modules/registrars/openprovider/src/Handle.php
+++ b/modules/registrars/openprovider/src/Handle.php
@@ -212,6 +212,36 @@ class Handle
     }
 
     /**
+     * Check whether there is a difference in the given handles.
+     *
+     * @param array $params
+     * @param string $type
+     * @return string|false
+     */
+    public function checkHandleEquality(array $params, string $type = 'registrant')
+    {
+        // Find the domain
+        $domain = Domain::find($params['domainid']);
+        $params['userid'] = $domain->userid;
+
+        try {
+            $this->model = $domain->handles()->wherePivot('type', $type)->firstOrFail();
+
+            $this->prepareHandle($params, $type);
+
+            $action = $this->findChanges($params);
+
+            if ($action === false) {
+                return $this->model->handle; // No changes, return existing handle
+            }
+        } catch (\Exception $e) {
+            // No existing handle found
+        }
+
+        return false; // Changes found or handle not found
+    }
+
+    /**
      * Set the additional fields for the handle.
      *
      * @param array $fields


### PR DESCRIPTION
**Bug**
Previously, the code used updateOrCreate() directly for all handle types, which resulted in creating a new customer for each handle type on the RCP side — even when the same handle details were reused.

**Fix**
The logic has been updated to loop through each handle type and track handle creation history. If the same handle details are encountered again, the previously created customer handle ID is reused instead of creating a new one.