### PR TITLE
Adding new contacts with required customerAdditionalData

### DIFF
--- a/lang/overrides/english.php
+++ b/lang/overrides/english.php
@@ -35,3 +35,14 @@ $_LANG['ptIdentificationNumber'] = 'Tipo de Contribuinte (VAT/TAX ID)';
 $_LANG['ptIdentificationVat'] = "NIPC (empresa)";
 $_LANG['ptIdentificationSocialSecurityNumber'] = "NIF (particular)";
 $_LANG['ptIdentificationCORI'] = 'Tipo de Contribuinte (VAT/TAX ID)';
+
+$_LANG['itIdentificationCompany'] = 'Company Registration Number';
+$_LANG['itIdentificationSocialSecurityNumber'] = 'Individual Codice Fiscale';
+
+$_LANG['seIdentificationCompany'] = 'Legal Entity';
+$_LANG['seIdentificationSocialSecurityNumber'] = 'Private individual';
+
+$_LANG['fiIdentificationCompany'] = 'Company Registration Number';
+$_LANG['fiIdentificationPassport'] = 'Passport/ID number for Individuals';
+$_LANG['fiIdentificationSocialSecurityNumber'] = 'Social Security Number for Individuals';
+$_LANG['fiIdentificationBirthDate'] = 'Birthday for Foreign Private Individuals (YYYY-MM-DD)';

--- a/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
@@ -134,24 +134,16 @@ class ShoppingCartController
                 $tld = explode('.', $domain['domain']);
 
                 if (in_array($tld[1], $domainsToMatch)) {
-                    $fieldData = array();
-                    foreach ($domain['fields'] as $field) {
-                        if (
-                            $field == 'passportNumber' ||
-                            $field == 'companyRegistrationNumber' ||
-                            $field == 'vat' ||
-                            $field == 'socialSecurityNumber'
-                        ) {
-                            $fieldData['field'] = $field;
-                        }
+                    $fieldsArray = array_values($domain['fields']);
+                    if (isset($fieldsArray[0]) && isset($fieldsArray[1])) {
+                        $fieldData = [
+                            'field' => $fieldsArray[0],
+                            'value' => $fieldsArray[1],
+                        ];
 
-                        if (!empty($fieldData['field'])) {
-                            $fieldData['value'] = $field;
+                        if (!empty($fieldData['value']) && !empty($fieldData['field']) && !empty($contactid)) {
+                            DB::updateOrCreateContact($fieldData['value'], $contactid, $fieldData['field']);
                         }
-                    }
-
-                    if (!empty($fieldData['value']) && !empty($fieldData['field']) && !empty($contactid)) {
-                        DB::updateOrCreateContact($fieldData['value'], $contactid, $fieldData['field']);
                     }
                 }
             }

--- a/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
@@ -16,11 +16,11 @@ class ShoppingCartController
         if ($idnumbermod) {
             $data = [];
             $domainTlds = [];
-            $domainsToMatch = ['es', 'pt', 'com.es', 'nom.es', 'edu.es', 'org.es'];
 
             foreach ($vars['cart']['domains'] as $domain) {
                 $domainName = $domain['domain'];
-                $tld = $this->getFullTld($domainName, $domainsToMatch);
+                $tld = $this->getFullTld($domainName);
+
                 if (!$tld) {
                     continue; // skip if TLD not matched
                 }
@@ -28,7 +28,7 @@ class ShoppingCartController
                 $domainTlds[$domainName] = $tld;
                 $fieldData = [];
 
-                if (in_array($tld, ['es', 'pt', 'com.es', 'nom.es', 'edu.es', 'org.es'])) {
+                if (in_array($tld, ['es', 'pt', 'se', 'com.es', 'nom.es', 'edu.es', 'org.es'])) {
                     $f         = 0;
                     foreach ($domain['fields'] as $field) {
                         $f++;
@@ -54,7 +54,11 @@ class ShoppingCartController
                         $name = '';
                         switch ($fields['field']) {
                             case 'companyRegistrationNumber':
-                                $name = $_LANG['esIdentificationCompany'];
+                                if (in_array($tld, ['es', 'com.es', 'nom.es', 'edu.es', 'org.es'])) {
+                                    $name = $_LANG['esIdentificationCompany'];
+                                } elseif ($tld === 'se') {
+                                    $name = $_LANG['seIdentificationCompany'];
+                                }
                                 break;
                             case 'passportNumber':
                                 $name = $_LANG['esIdentificationPassport'];
@@ -63,7 +67,11 @@ class ShoppingCartController
                                 $name = $_LANG['ptIdentificationVat'];
                                 break;
                             case 'socialSecurityNumber':
-                                $name = $_LANG['ptIdentificationSocialSecurityNumber'];
+                                if ($tld === 'pt') {
+                                    $name = $_LANG['ptIdentificationSocialSecurityNumber'];
+                                } elseif ($tld === 'se') {
+                                    $name = $_LANG['seIdentificationSocialSecurityNumber'];
+                                }
                                 break;
                         }
 
@@ -115,13 +123,17 @@ class ShoppingCartController
         }
     }
 
-    private function getFullTld(string $domainName, array $domainsToMatch): ?string
+    private function getFullTld(string $domainName): string
     {
-        foreach ($domainsToMatch as $tld) {
-            if (str_ends_with($domainName, '.' . $tld)) {
-                return $tld;
+        $multiTlds = ['com.es', 'nom.es', 'edu.es', 'org.es'];
+
+        foreach ($multiTlds as $multiTld) {
+            if (str_ends_with($domainName, '.' . $multiTld)) {
+                return $multiTld;
             }
         }
-        return null;
+
+        $tld = explode('.', $domainName)[1];
+        return $tld;
     }
 }

--- a/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
@@ -19,6 +19,7 @@ class ShoppingCartController
 
             foreach ($vars['cart']['domains'] as $domain) {
                 $domainName = $domain['domain'];
+                $fields = $domain['fields'];
                 $tld = $this->getFullTld($domainName);
 
                 if (!$tld) {
@@ -30,7 +31,7 @@ class ShoppingCartController
 
                 if (in_array($tld, ['es', 'pt', 'se', 'com.es', 'nom.es', 'edu.es', 'org.es'])) {
                     $f         = 0;
-                    foreach ($domain['fields'] as $field) {
+                    foreach ($fields as $field) {
                         $f++;
                         switch ($f) {
                             case 1:
@@ -42,7 +43,7 @@ class ShoppingCartController
                         }
                     }
                     if (!empty($fieldData['field']) && !empty($fieldData['value'])) {
-                        $data[$domain['domain']] = [$fieldData];
+                        $data[$domainName] = [$fieldData];
                     }
                 } elseif ($tld === 'it') {
                     $itFieldsMap = [
@@ -50,19 +51,19 @@ class ShoppingCartController
                         9 => 'socialSecurityNumber',
                     ];
 
-                    $mappedFields = [];
-                    foreach ($itFieldsMap as $index => $name) {
-                        if (!empty($domain['fields'][$index])) {
-                            $mappedFields[] = [
-                                'field' => $name,
-                                'value' => $domain['fields'][$index],
-                            ];
-                        }
-                    }
+                    $mappedFields = $this->mapFieldsByIndex($fields, $itFieldsMap);
+                } elseif ($tld === 'fi') {
+                    $fiFieldsMap = [
+                        1 => 'companyRegistrationNumber',
+                        2 => 'passportNumber',
+                        3 => 'socialSecurityNumber',
+                        4 => 'birthDate',
+                    ];
 
-                    if (!empty($mappedFields)) {
-                        $data[$domain['domain']] = $mappedFields;
-                    }
+                    $mappedFields = $this->mapFieldsByIndex($fields, $fiFieldsMap);
+                }
+                if (!empty($mappedFields)) {
+                    $data[$domainName] = $mappedFields;
                 }
             }
 
@@ -79,11 +80,15 @@ class ShoppingCartController
                                     $name = $_LANG['seIdentificationCompany'];
                                 } elseif ($tld === 'it') {
                                     $name = $_LANG['itIdentificationCompany'];
+                                } elseif ($tld === 'fi') {
+                                    $name = $_LANG['fiIdentificationCompany'];
                                 }
                                 break;
                             case 'passportNumber':
                                 if (in_array($tld, ['es', 'com.es', 'nom.es', 'edu.es', 'org.es'])) {
                                     $name = $_LANG['esIdentificationPassport'];
+                                } elseif ($tld === 'fi') {
+                                    $name = $_LANG['fiIdentificationPassport'];
                                 }
                                 break;
                             case 'vat':
@@ -96,7 +101,12 @@ class ShoppingCartController
                                     $name = $_LANG['seIdentificationSocialSecurityNumber'];
                                 } elseif ($tld === 'it') {
                                     $name = $_LANG['itIdentificationSocialSecurityNumber'];
+                                } elseif ($tld === 'fi') {
+                                    $name = $_LANG['fiIdentificationSocialSecurityNumber'];
                                 }
+                                break;
+                            case 'birthDate':
+                                $name = $_LANG['fiIdentificationBirthDate'];
                                 break;
                         }
 
@@ -160,5 +170,19 @@ class ShoppingCartController
 
         $tld = explode('.', $domainName)[1];
         return $tld;
+    }
+
+    private function mapFieldsByIndex(array $fields, array $map): array
+    {
+        $result = [];
+        foreach ($map as $index => $fieldName) {
+            if (!empty($fields[$index])) {
+                $result[] = [
+                    'field' => $fieldName,
+                    'value' => $fields[$index],
+                ];
+            }
+        }
+        return $result;
     }
 }

--- a/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
@@ -149,6 +149,12 @@ class ShoppingCartController
                             DB::updateOrCreateContact($fieldData['value'], $contactid, $fieldData['field']);
                         }
                     }
+                } elseif ($tld === 'it') {
+                    $itFieldsMap = [
+                        7 => 'companyRegistrationNumber',
+                        9 => 'socialSecurityNumber',
+                    ];
+                    $this->updateContactFields($itFieldsMap, $fields, $contactid);
                 }
             }
         }
@@ -180,5 +186,19 @@ class ShoppingCartController
             }
         }
         return $result;
+    }
+
+    private function updateContactFields(array $map, array $fields, $contactId): void
+    {
+        foreach ($map as $index => $fieldName) {
+            if (!empty($fields[$index])) {
+                $fieldData = [
+                    'field' => $fieldName,
+                    'value' => $fields[$index],
+                ];
+
+                DB::updateOrCreateContact($fieldData['value'], $contactId, $fieldData['field']);
+            }
+        }
     }
 }

--- a/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
@@ -126,15 +126,19 @@ class ShoppingCartController
         $idnumbermod = Configuration::get('idnumbermod');
 
         if ($idnumbermod) {
-            $domainsToMatch = array('es', 'pt');
+
             $contactid      = $vars['contact'];
 
             foreach ($vars['domains'] as $domain) {
+                $domainName = $domain['domain'];
+                $fields = $domain['fields'];
+                $tld = $this->getFullTld($domainName);
 
-                $tld = explode('.', $domain['domain']);
-
-                if (in_array($tld[1], $domainsToMatch)) {
-                    $fieldsArray = array_values($domain['fields']);
+                if (!$tld || empty($fields) || empty($contactid)) {
+                    continue;
+                }
+                if (in_array($tld, ['es', 'pt', 'se', 'com.es', 'nom.es', 'edu.es', 'org.es'])) {
+                    $fieldsArray = array_values($fields);
                     if (isset($fieldsArray[0]) && isset($fieldsArray[1])) {
                         $fieldData = [
                             'field' => $fieldsArray[0],

--- a/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
@@ -9,7 +9,7 @@ class ShoppingCartController
 {
     public function checkoutOutput($vars)
     {
-        GLOBAL $_LANG;
+        global $_LANG;
 
         $idnumbermod = Configuration::get('idnumbermod');
 
@@ -23,7 +23,7 @@ class ShoppingCartController
                 $tld = $this->getFullTld($domainName);
 
                 if (!$tld) {
-                    continue; // skip if TLD not matched
+                    continue;
                 }
 
                 $domainTlds[$domainName] = $tld;
@@ -155,6 +155,14 @@ class ShoppingCartController
                         9 => 'socialSecurityNumber',
                     ];
                     $this->updateContactFields($itFieldsMap, $fields, $contactid);
+                } elseif ($tld === 'fi') {
+                    $fiFieldsMap = [
+                        1 => 'companyRegistrationNumber',
+                        2 => 'passportNumber',
+                        3 => 'socialSecurityNumber',
+                        4 => 'birthDate',
+                    ];
+                    $this->updateContactFields($fiFieldsMap, $fields, $contactid);
                 }
             }
         }

--- a/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
@@ -44,6 +44,25 @@ class ShoppingCartController
                     if (!empty($fieldData['field']) && !empty($fieldData['value'])) {
                         $data[$domain['domain']] = [$fieldData];
                     }
+                } elseif ($tld === 'it') {
+                    $itFieldsMap = [
+                        7 => 'companyRegistrationNumber',
+                        9 => 'socialSecurityNumber',
+                    ];
+
+                    $mappedFields = [];
+                    foreach ($itFieldsMap as $index => $name) {
+                        if (!empty($domain['fields'][$index])) {
+                            $mappedFields[] = [
+                                'field' => $name,
+                                'value' => $domain['fields'][$index],
+                            ];
+                        }
+                    }
+
+                    if (!empty($mappedFields)) {
+                        $data[$domain['domain']] = $mappedFields;
+                    }
                 }
             }
 
@@ -58,10 +77,14 @@ class ShoppingCartController
                                     $name = $_LANG['esIdentificationCompany'];
                                 } elseif ($tld === 'se') {
                                     $name = $_LANG['seIdentificationCompany'];
+                                } elseif ($tld === 'it') {
+                                    $name = $_LANG['itIdentificationCompany'];
                                 }
                                 break;
                             case 'passportNumber':
-                                $name = $_LANG['esIdentificationPassport'];
+                                if (in_array($tld, ['es', 'com.es', 'nom.es', 'edu.es', 'org.es'])) {
+                                    $name = $_LANG['esIdentificationPassport'];
+                                }
                                 break;
                             case 'vat':
                                 $name = $_LANG['ptIdentificationVat'];
@@ -71,6 +94,8 @@ class ShoppingCartController
                                     $name = $_LANG['ptIdentificationSocialSecurityNumber'];
                                 } elseif ($tld === 'se') {
                                     $name = $_LANG['seIdentificationSocialSecurityNumber'];
+                                } elseif ($tld === 'it') {
+                                    $name = $_LANG['itIdentificationSocialSecurityNumber'];
                                 }
                                 break;
                         }


### PR DESCRIPTION
- Updated ShoppingCartCheckoutOutput hook to show customerAdditionalData for .se, .it, .fi, com.es, nom.es, edu.es, and org.es when creating a new contact during domain registration.

- Updated PreShoppingCartCheckout hook to store the customerAdditionalData for .es, .se, .it, .fi, com.es, nom.es, edu.es, and org.es when creating a new contact during domain registration.

- Updated /lang/overrides/english.php file.