### PR TITLE
Intgrtns 333 whmcs add consent for publishing parameter to g tl ds 

### DIFF
--- a/modules/registrars/openprovider/configuration/additionalfields.php
+++ b/modules/registrars/openprovider/configuration/additionalfields.php
@@ -55,7 +55,6 @@ $additionaldomainfields[".travel"][] = array(
     "op_location" => "customerExtensionAdditionalData",
     "op_name" => "uin",
 );
-op_addConsentField($additionaldomainfields, ".travel", true);
 
 // .XXX
 $additionaldomainfields[".xxx"][] = array(
@@ -73,7 +72,6 @@ $additionaldomainfields[".xxx"][] = array(
     "op_location" => "customerExtensionAdditionalData",
     "op_name" => "defensive",
 );
-op_addConsentField($additionaldomainfields, ".xxx", true);
 
 // .JOBS
 $additionaldomainfields[".jobs"][] = array(
@@ -120,7 +118,6 @@ $additionaldomainfields[".jobs"][] = array(
     "op_location" => "customerExtensionAdditionalData",
     "op_name" => "hrMember"
 );
-op_addConsentField($additionaldomainfields, ".jobs", true);
 
 // .AERO
 $additionaldomainfields[".aero"][] = array(
@@ -140,7 +137,6 @@ $additionaldomainfields[".aero"][] = array(
     "op_location" => "customerExtensionAdditionalData",
     "op_name" => "ensKey"
 );
-op_addConsentField($additionaldomainfields, ".aero", true);
 
 // .PT
 $additionaldomainfields[".pt"][] = array(
@@ -496,8 +492,6 @@ $additionaldomainfields[".com"][] = array(
     "op_name" => "idnScript"
 );
 
-op_addConsentField($additionaldomainfields, ".com", true);
-
 // .NET
 $additionaldomainfields[".net"] = $additionaldomainfields[".com"];
 
@@ -513,8 +507,6 @@ $additionaldomainfields[".org"][] = array(
     "op_skip" => "None"
 );
 
-op_addConsentField($additionaldomainfields, ".org", true);
-
 // .VOTO
 $additionaldomainfields[".voto"][] = array(
     "Name" => "Accept Voto Registry Policy",
@@ -525,8 +517,6 @@ $additionaldomainfields[".voto"][] = array(
     "op_name" => "votoAcceptance"
 );
 
-op_addConsentField($additionaldomainfields, ".voto", true);
-
 // .VOTE
 $additionaldomainfields[".vote"][] = array(
     "Name" => "Accept Vote Registry Policy",
@@ -536,8 +526,6 @@ $additionaldomainfields[".vote"][] = array(
     "op_location" => "domainAdditionalData",
     "op_name" => "voteAcceptance"
 );
-
-op_addConsentField($additionaldomainfields, ".vote", true);
 
 // .SCOT
 $additionaldomainfields[".scot"][] = array(
@@ -567,8 +555,6 @@ $additionaldomainfields[".scot"][] = array(
     "op_location" => "domainAdditionalData",
     "op_name" => "domainNameVariants"
 );
-
-op_addConsentField($additionaldomainfields, ".scot", true);
 
 // .EUS
 $additionaldomainfields[".eus"] = $additionaldomainfields[".scot"];
@@ -632,8 +618,6 @@ $additionaldomainfields[".democrat"][] = array(
     "op_name" => "idnScript",
     "op_skip" => "None"
 );
-
-op_addConsentField($additionaldomainfields, ".democrat", true);
 
 // .DANCE
 $additionaldomainfields[".dance"] = $additionaldomainfields[".democrat"];
@@ -734,8 +718,6 @@ $additionaldomainfields[".immobilien"][] = array(
     "op_skip" => "None"
 );
 
-op_addConsentField($additionaldomainfields, ".immobilien", true);
-
 // .KAUFEN
 $additionaldomainfields[".kaufen"] = $additionaldomainfields[".immobilien"];
 
@@ -753,8 +735,6 @@ $additionaldomainfields[".nrw"][] = array(
     "op_name" => "idnScript",
     "op_skip" => "None"
 );
-
-op_addConsentField($additionaldomainfields, ".nrw", true);
 
 // .OPR (xn--c1avg)
 $additionaldomainfields[".opr"][] = array(
@@ -804,8 +784,6 @@ $additionaldomainfields[".swiss"][] = array(
     "op_name" => "intendedUse"
 );
 
-op_addConsentField($additionaldomainfields, ".swiss", true);
-
 // .RADIO
 $additionaldomainfields[".radio"][] = array(
     "Name" => "Intended Use",
@@ -815,8 +793,6 @@ $additionaldomainfields[".radio"][] = array(
     "op_location" => "domainAdditionalData",
     "op_name" => "intendedUse"
 );
-
-op_addConsentField($additionaldomainfields, ".radio", true);
 
 // .LAW
 $additionaldomainfields[".law"][] = array(
@@ -873,8 +849,6 @@ $additionaldomainfields[".law"][] = array(
     "op_name" => "lawAcceptance"
 );
 
-op_addConsentField($additionaldomainfields, ".law", true);
-
 // .FI
 $additionaldomainfields[".fi"][] = array(
     "Name" => "Organisation Type",
@@ -913,8 +887,6 @@ $additionaldomainfields[".pro"][] = array(
     "Remove" => true,
 );
 
-op_addConsentField($additionaldomainfields, ".pro", true);
-
 // .TOP
 $additionaldomainfields[".top"][] = array(
     "Name" => "Internationalized domain name Script (only for IDN domains)",
@@ -926,8 +898,6 @@ $additionaldomainfields[".top"][] = array(
     "op_name" => "idnScript",
     "op_skip" => "None"
 );
-
-op_addConsentField($additionaldomainfields, ".top", true);
 
 // .EU
 $additionaldomainfields[".eu"][] = array(
@@ -996,9 +966,9 @@ $gtldsToAdd = array(
     '.crown', '.crs', '.cruise', '.cruises', '.csc', '.cuisinella', '.cymru', '.cyou',
     
     // D
-    '.dabur', '.dad', '.data', '.date', '.dating', '.datsun', '.day', '.dclk', '.dds',
-    '.deal', '.dealer', '.deals', '.delivery', '.dell', '.deloitte', '.delta', '.dental',
-    '.desi', '.design', '.dev', '.dhl', '.diamonds', '.diet', '.digital', '.direct', '.directory',
+    '.dabur', '.dad', '.data', '.date', '.dating', '.datsun', '.day', '.dclk', '.dds', '.degree',
+    '.deal', '.dealer', '.deals', '.delivery', '.dell', '.deloitte', '.delta', '.dental', '.dentist', 
+    '.democrat','.desi', '.design', '.dev', '.dhl', '.diamonds', '.diet', '.digital', '.direct', '.directory',
     '.discount', '.discover', '.dish', '.diy', '.dnp', '.docs', '.doctor', '.dodge', '.dog', '.doha',
     '.domains', '.doosan', '.dot', '.download', '.drive', '.dtv', '.dubai', '.duck', '.dunlop', '.duns',
     '.dupont', '.durban', '.dvag', '.dvr',

--- a/modules/registrars/openprovider/configuration/additionalfields.php
+++ b/modules/registrars/openprovider/configuration/additionalfields.php
@@ -958,3 +958,203 @@ $additionaldomainfields[".dk"][] = array(
     "op_location" => "domainAdditionalData",
     "op_name" => "dkAcceptance"
 );
+
+$gtldsToAdd = array(
+    // A
+    '.aaa','.aarp','.abarth','.abb','.abbott','.abbvie','.abc','.able','.abogado','.abudhabi',
+    '.academy','.accenture','.accountant','.accountants','.aco','.active','.actor','.adac','.ads','.adult',
+    '.aeg','.aero','.aetna','.afamilycompany','.afl','.africa','.agakhan','.agency','.aig','.aigo',
+    '.airbus','.airforce','.airtel','.akdn','.alfaromeo','.alibaba','.alipay','.allfinanz','.allstate','.ally',
+    '.alsace','.alstom','.amazon','.americanexpress','.americanfamily','.amex','.amfam','.amica','.amsterdam','.analytics',
+    '.android','.anquan','.anz','.aol','.apartments','.app','.apple','.aquarelle','.arab','.aramco',
+    '.archi','.army','.arpa','.art','.arte','.asda','.asia','.associates','.athleta','.attorney',
+    '.auction','.audi','.audible','.audio','.auspost','.author','.auto','.autos','.avianca','.aws',
+    '.axa','.azure',
+    
+    // B
+    '.baby','.baidu','.banamex','.bananarepublic','.band','.bank','.bar','.barcelona',
+    '.barclaycard','.barclays','.barefoot','.bargains','.baseball','.basketball','.bauhaus',
+    '.bayern','.bbc','.bbt','.bbva','.bcg','.bcn','.beats','.beauty','.beer','.bentley',
+    '.berlin','.best','.bestbuy','.bet','.bharti','.bible','.bid','.bike','.bing','.bingo',
+    '.bio','.biz','.black','.blackfriday','.blanco','.blockbuster','.blog','.bloomberg',
+    '.blue','.bms','.bmw','.bnl','.bnpparibas','.boats','.boehringer','.bofa','.bom',
+    '.bond','.boo','.book','.booking','.boots','.bosch','.bostik','.boston','.bot',
+    '.boutique','.box','.bradesco','.bridgestone','.broadway','.broker','.brother',
+    '.brussels','.budapest','.bugatti','.build','.builders','.business','.buy','.buzz','.bzh',
+    
+    // C
+    '.cab', '.cafe', '.cal', '.call', '.calvinklein', '.cam', '.camera', '.camp', '.cancerresearch', '.canon',
+    '.capetown', '.capital', '.capitalone', '.car', '.caravan', '.cards', '.care', '.career', '.careers', '.cars',
+    '.cartier', '.casa', '.case', '.caseih', '.cash', '.casino', '.cat', '.catering', '.catholic', '.cba',
+    '.cbn', '.cbre', '.cbs', '.ceb', '.center', '.ceo', '.cern', '.cfa', '.cfd', '.chanel',
+    '.channel', '.charity', '.chase', '.chat', '.cheap', '.chintai', '.chloe', '.christmas', '.chrome', '.chrysler',
+    '.church', '.cipriani', '.circle', '.cisco', '.citadel', '.citi', '.citic', '.city', '.cityeats', '.claims',
+    '.cleaning', '.click', '.clinic', '.clinique', '.clothing', '.cloud', '.club', '.clubmed', '.coach', '.codes',
+    '.coffee', '.college', '.cologne', '.com', '.comcast', '.commbank', '.community', '.company', '.compare', '.computer',
+    '.comsec', '.condos', '.construction', '.consulting', '.contact', '.contractors', '.cooking', '.cookingchannel', '.cool', '.coop',
+    '.corsica', '.country', '.coupon', '.coupons', '.courses', '.cpa', '.credit', '.creditcard', '.creditunion', '.cricket',
+    '.crown', '.crs', '.cruise', '.cruises', '.csc', '.cuisinella', '.cymru', '.cyou',
+    
+    // D
+    '.dabur', '.dad', '.data', '.date', '.dating', '.datsun', '.day', '.dclk', '.dds',
+    '.deal', '.dealer', '.deals', '.delivery', '.dell', '.deloitte', '.delta', '.dental',
+    '.desi', '.design', '.dev', '.dhl', '.diamonds', '.diet', '.digital', '.direct', '.directory',
+    '.discount', '.discover', '.dish', '.diy', '.dnp', '.docs', '.doctor', '.dodge', '.dog', '.doha',
+    '.domains', '.doosan', '.dot', '.download', '.drive', '.dtv', '.dubai', '.duck', '.dunlop', '.duns',
+    '.dupont', '.durban', '.dvag', '.dvr',
+    
+    // E
+    '.earth', '.eat', '.eco', '.edeka', '.edu', '.education', '.email', '.emerck', '.energy', '.engineer',
+    '.engineering', '.enterprises', '.epost', '.epson', '.equipment', '.ericsson', '.erni', '.esq', '.estate', '.esurance',
+    '.etisalat', '.eurovision', '.eus', '.events', '.everbank', '.exchange', '.expert', '.exposed', '.express', '.extraspace',
+    
+    // F
+    '.fage', '.fail', '.fairwinds', '.faith', '.family', '.fan', '.fans', '.farm', '.farmers', '.fashion',
+    '.fast', '.fedex', '.feedback', '.ferrari', '.ferrero', '.fiat', '.fidelity', '.fido', '.film', '.final',
+    '.finance', '.financial', '.fire', '.firestone', '.firmdale', '.fish', '.fishing', '.fit', '.fitness', '.flickr',
+    '.flights', '.flir', '.florist', '.flowers', '.flsmidth', '.fly', '.foo', '.food', '.foodnetwork', '.football',
+    '.ford', '.forex', '.forsale', '.forum', '.foundation', '.fox', '.free', '.fresenius', '.frl', '.frogans',
+    '.frontdoor', '.frontier', '.ftr', '.fujitsu', '.fujixerox', '.fun', '.fund', '.furniture', '.futbol', '.fyi',
+
+    // G
+    '.gal', '.gallery', '.gallo', '.gallup', '.game', '.games', '.gap', '.garden', '.gay', '.gbiz',
+    '.gdn', '.gea', '.gent', '.genting', '.george', '.ggee', '.gift', '.gifts', '.gives', '.giving',
+    '.glade', '.glass', '.gle', '.global', '.globo', '.gmail', '.gmbh', '.gmo', '.gmx', '.godaddy',
+    '.gold', '.goldpoint', '.golf', '.goo', '.goodhands', '.goodyear', '.goog', '.google', '.gop', '.got',
+    '.gov', '.grainger', '.graphics', '.gratis', '.green', '.gripe', '.grocery', '.group', '.guardian', '.gucci',
+    '.guge', '.guide', '.guitars', '.guru',
+
+    // H
+    '.hair', '.hamburg', '.hangout', '.haus', '.hbo', '.hdfc', '.hdfcbank', '.health', '.healthcare', '.help',
+    '.helsinki', '.here', '.hermes', '.hgtv', '.hiphop', '.hisamitsu', '.hitachi', '.hiv', '.hkt', '.hockey',
+    '.holdings', '.holiday', '.homedepot', '.homegoods', '.homes', '.homesense', '.honda', '.honeywell', '.horse', '.hospital',
+    '.host', '.hosting', '.hot', '.hoteles', '.hotels', '.hotmail', '.house', '.how', '.hsbc', '.htc',
+    '.hughes', '.hyatt', '.hyundai',
+
+    // I
+    '.ibm', '.icbc', '.ice', '.icu', '.ieee', '.ifm', '.iinet', '.ikano', '.imamat', '.imdb',
+    '.immo', '.immobilien', '.inc', '.industries', '.infiniti', '.info', '.ing', '.ink', '.institute', '.insurance',
+    '.insure', '.int', '.intel', '.international', '.intuit', '.investments', '.ipiranga', '.irish', '.iselect', '.ismaili',
+    '.ist', '.istanbul', '.itau', '.itv', '.iveco', '.iwc',
+
+    // J
+    '.jaguar', '.java', '.jcb', '.jcp', '.jeep', '.jetzt', '.jewelry', '.jio', '.jlc', '.jll',
+    '.jmp', '.jnj', '.jobs', '.joburg', '.jot', '.joy', '.jpmorgan', '.jprs', '.juegos', '.juniper',
+
+    // K
+    '.kaufen', '.kddi', '.kerryhotels', '.kerrylogistics', '.kerryproperties', '.kfh', '.kia', '.kids', '.kim', '.kinder',
+    '.kindle', '.kitchen', '.kiwi', '.koeln', '.komatsu', '.kosher', '.kpmg', '.kpn', '.krd', '.kred',
+    '.kuokgroup', '.kyoto',
+
+    // L
+    '.lacaixa', '.ladbrokes', '.lamborghini', '.lamer', '.lancaster', '.lancia', '.lancome', '.land', '.landrover', '.lanxess',
+    '.lasalle', '.lat', '.latino', '.latrobe', '.law', '.lawyer', '.lds', '.lease', '.leclerc', '.lefrak',
+    '.legal', '.lego', '.lexus', '.lgbt', '.liaison', '.lidl', '.life', '.lifeinsurance', '.lifestyle', '.lighting',
+    '.like', '.lilly', '.limited', '.limo', '.lincoln', '.linde', '.link', '.lipsy', '.live', '.living',
+    '.lixil', '.llc', '.llp', '.loan', '.loans', '.locker', '.locus', '.loft', '.lol', '.london',
+    '.lotte', '.lotto', '.love', '.lpl', '.lplfinancial', '.ltd', '.ltda', '.lundbeck', '.lupin', '.luxe',
+    '.luxury',
+
+    // M
+    '.macys', '.madrid', '.maif', '.maison', '.makeup', '.man', '.management', '.mango', '.map', '.market',
+    '.marketing', '.markets', '.marriott', '.marshalls', '.maserati', '.mattel', '.mba', '.mcd', '.mcdonalds', '.mckinsey',
+    '.med', '.media', '.meet', '.melbourne', '.meme', '.memorial', '.men', '.menu', '.meo', '.merckmsd',
+    '.metlife', '.miami', '.microsoft', '.mil', '.mini', '.mint', '.mit', '.mitsubishi', '.mlb', '.mls',
+    '.mma', '.mobi', '.mobile', '.mobily', '.moda', '.moe', '.moi', '.mom', '.monash', '.money',
+    '.monster', '.montblanc', '.mopar', '.mormon', '.mortgage', '.moscow', '.moto', '.motorcycles', '.mov', '.movie',
+    '.movistar', '.msd', '.mtn', '.mtpc', '.mtr', '.museum', '.music', '.mutual', '.mutuelle',
+
+    // N
+    '.nab', '.nadex', '.nagoya', '.name', '.nationwide', '.natura', '.navy', '.nba', '.nec', '.net',
+    '.netbank', '.netflix', '.network', '.neustar', '.new', '.newholland', '.news', '.next', '.nextdirect', '.nexus',
+    '.nfl', '.ngo', '.nhk', '.nico', '.nike', '.nikon', '.ninja', '.nissan', '.nissay', '.nokia',
+    '.northwesternmutual', '.norton', '.now', '.nowruz', '.nowtv', '.nra', '.nrw', '.ntt', '.nyc',
+
+    // O
+    '.obi', '.observer', '.off', '.office', '.okinawa', '.olayan', '.olayangroup', '.oldnavy', '.ollo', '.omega',
+    '.one', '.ong', '.onl', '.online', '.onyourside', '.ooo', '.open', '.oracle', '.orange', '.org',
+    '.organic', '.orientexpress', '.origins', '.osaka', '.otsuka', '.ott', '.ovh',
+
+    // P
+    '.page', '.pamperedchef', '.panasonic', '.panerai', '.paris', '.pars', '.partners', '.parts', '.party', '.passagens',
+    '.pay', '.pccw', '.pet', '.pfizer', '.pharmacy', '.phd', '.philips', '.phone', '.photo', '.photography',
+    '.photos', '.physio', '.piaget', '.pics', '.pictet', '.pictures', '.pid', '.pin', '.ping', '.pink',
+    '.pioneer', '.pizza', '.place', '.play', '.playstation', '.plumbing', '.plus', '.pnc', '.pohl', '.poker',
+    '.politie', '.porn', '.post', '.pramerica', '.praxi', '.press', '.prime', '.pro', '.prod', '.productions',
+    '.prof', '.progressive', '.promo', '.properties', '.property', '.protection', '.pru', '.prudential', '.pub', '.pwc',
+
+    // Q
+    '.qpon', '.quebec', '.quest', '.qvc',
+
+    // R
+    '.racing', '.radio', '.raid', '.read', '.realestate', '.realtor', '.realty', '.recipes', '.red', '.redstone',
+    '.redumbrella', '.rehab', '.reise', '.reisen', '.reit', '.reliance', '.ren', '.rent', '.rentals', '.repair',
+    '.report', '.republican', '.rest', '.restaurant', '.review', '.reviews', '.rexroth', '.rich', '.richardli', '.ricoh',
+    '.rightathome', '.ril', '.rio', '.rip', '.rmit', '.rocher', '.rocks', '.rodeo', '.rogers', '.room',
+    '.rsvp', '.rugby', '.ruhr', '.run', '.rwe', '.ryukyu',
+
+    // S
+    '.saarland', '.safe', '.safety', '.sakura', '.sale', '.salon', '.samsclub', '.samsung', '.sandvik', '.sandvikcoromant',
+    '.sanofi', '.sap', '.sapo', '.sarl', '.sas', '.save', '.saxo', '.sbi', '.sbs', '.sca',
+    '.scb', '.schaeffler', '.schmidt', '.scholarships', '.school', '.schule', '.schwarz', '.science', '.scjohnson', '.scor',
+    '.scot', '.search', '.seat', '.secure', '.security', '.seek', '.select', '.sener', '.services', '.ses',
+    '.seven', '.sew', '.sex', '.sexy', '.sfr', '.shangrila', '.sharp', '.shaw', '.shell', '.shia',
+    '.shiksha', '.shoes', '.shop', '.shopping', '.shouji', '.show', '.showtime', '.shriram', '.silk', '.sina',
+    '.singles', '.site', '.ski', '.skin', '.sky', '.skype', '.sling', '.smart', '.smile', '.sncf',
+    '.soccer', '.social', '.softbank', '.software', '.sohu', '.solar', '.solutions', '.song', '.sony', '.soy',
+    '.spa', '.space', '.spiegel', '.sport', '.spot', '.spreadbetting', '.srl', '.srt', '.stada', '.staples',
+    '.star', '.starhub', '.statebank', '.statefarm', '.statoil', '.stc', '.stcgroup', '.stockholm', '.storage', '.store',
+    '.stream', '.studio', '.study', '.style', '.sucks', '.supplies', '.supply', '.support', '.surf', '.surgery',
+    '.suzuki', '.swatch', '.swiftcover', '.swiss', '.sydney', '.symantec', '.systems',
+
+    // T
+    '.tab', '.taipei', '.talk', '.taobao', '.target', '.tatamotors', '.tatar', '.tattoo', '.tax', '.taxi',
+    '.tci', '.tdk', '.team', '.tech', '.technology', '.tel', '.telecity', '.telefonica', '.temasek', '.tennis',
+    '.teva', '.thd', '.theater', '.theatre', '.tiaa', '.tickets', '.tienda', '.tiffany', '.tips', '.tires',
+    '.tirol', '.tjmaxx', '.tjx', '.tkmaxx', '.tmall', '.today', '.tokyo', '.tools', '.top', '.toray',
+    '.toshiba', '.total', '.tours', '.town', '.toyota', '.toys', '.trade', '.trading', '.training', '.travel',
+    '.travelchannel', '.travelers', '.travelersinsurance', '.trust', '.trv', '.tube', '.tui', '.tunes', '.tushu', '.tvs',
+
+    // U
+    '.ubank', '.ubs', '.uconnect', '.unicom', '.university', '.uno', '.uol', '.ups',
+
+    // V
+    '.vacations', '.vana', '.vanguard', '.vegas', '.ventures', '.verisign', '.versicherung', '.vet', '.viajes', '.video',
+    '.vig', '.viking', '.villas', '.vin', '.vip', '.virgin', '.visa', '.vision', '.vista', '.vistaprint',
+    '.viva', '.vivo', '.vlaanderen', '.vodka', '.volkswagen', '.volvo', '.vote', '.voting', '.voto', '.voyage',
+    '.vuelos',
+
+    // W
+    '.wales', '.walmart', '.walter', '.wang', '.wanggou', '.warman', '.watch', '.watches', '.weather', '.weatherchannel',
+    '.webcam', '.weber', '.website', '.wed', '.wedding', '.weibo', '.weir', '.whoswho', '.wien', '.wiki',
+    '.williamhill', '.win', '.windows', '.wine', '.winners', '.wme', '.wolterskluwer', '.woodside', '.work', '.works',
+    '.world', '.wow', '.wtc', '.wtf',
+
+    // X
+    '.xbox', '.xerox', '.xfinity', '.xihuan', '.xin',
+
+    // IDN (Unicode labels)
+    '.कॉम', '.セール', '.佛山', '.慈善', '.集团', '.在线', '.大众汽车', '.点看', '.คอม', '.八卦',
+    '.موقع', '.公益', '.公司', '.香格里拉', '.网站', '.移动', '.我爱你', '.москва', '.католик', '.онлайн',
+    '.сайт', '.联通', '.קום', '.时尚', '.微博', '.淡马锡', '.ファッション', '.орг', '.नेट', '.ストア',
+    '.アマゾン', '.삼성', '.商标', '.商店', '.商城', '.дети', '.ポイント', '.新闻', '.工行', '.家電',
+    '.كوم', '.中文网', '.中信', '.娱乐', '.谷歌', '.電訊盈科', '.购物', '.クラウド', '.通販', '.网店',
+    '.संगठन', '.餐厅', '.网络', '.ком', '.亚马逊', '.诺基亚', '.食品', '.飞利浦', '.手表', '.手机',
+    '.ارامكو', '.العليان', '.اتصالات', '.بازار', '.موبايلي', '.ابوظبي', '.كاثوليك', '.همراه', '.닷컴', '.政府',
+    '.شبكة', '.بيتك', '.عرب', '.机构', '.组织机构', '.健康', '.招聘', '.рус', '.珠宝', '.大拿',
+    '.みんな', '.グーグル', '.世界', '.書籍', '.网址', '.닷넷', '.コム', '.天主教', '.游戏', '.vermögensberater',
+    '.vermögensberatung', '.企业', '.信息', '.嘉里大酒店', '.嘉里', '.广东', '.政务',
+
+    // X
+    '.xperia', '.xxx', '.xyz',
+
+    // Y
+    '.yachts', '.yahoo', '.yamaxun', '.yandex', '.yodobashi', '.yoga', '.yokohama', '.you', '.youtube', '.yun',
+
+    // Z
+    '.zappos', '.zara', '.zero', '.zip', '.zippo', '.zone', '.zuerich',
+);
+foreach ($gtldsToAdd as $gtld) {
+    // $additionaldomainfields[$gtld] = $additionaldomainfields[".com"];
+    op_addConsentField($additionaldomainfields, $gtld, true);
+}

--- a/modules/registrars/openprovider/configuration/additionalfields.php
+++ b/modules/registrars/openprovider/configuration/additionalfields.php
@@ -1155,6 +1155,5 @@ $gtldsToAdd = array(
     '.zappos', '.zara', '.zero', '.zip', '.zippo', '.zone', '.zuerich',
 );
 foreach ($gtldsToAdd as $gtld) {
-    // $additionaldomainfields[$gtld] = $additionaldomainfields[".com"];
     op_addConsentField($additionaldomainfields, $gtld, true);
 }

--- a/modules/registrars/openprovider/configuration/additionalfields.php
+++ b/modules/registrars/openprovider/configuration/additionalfields.php
@@ -7,6 +7,24 @@
  * @copyright Copyright (c) Openprovider 2018
  */
 
+if (!function_exists('op_addConsentField')) {
+    function op_addConsentField(array &$additionaldomainfields, string $tld, bool $required = false): void
+    {
+        $additionaldomainfields[$tld][] = array(
+            "Name"        => "Consent to Publish Domain Information",
+            "LangVar"     => "consentForPublishing",
+            "Type"        => "tickbox",
+            "Description" => '<span style="display:block;margin-top:6px;font-size:12px;line-height:1.45;color:#6b7280;max-width:100%;">'
+                           . 'Your data is redacted by default to protect your privacy. '
+                           . 'If you allow publication, the contact information will be treated as public and non-personal data.'
+                           . '</span>',
+            "Required"    => $required,          
+            "op_location" => "domainAdditionalData",
+            "op_name"     => "consentForPublishing",
+        );
+    }
+}
+
 // .US
 $additionaldomainfields[".us"][] = array(
     "Name" => "Nexus Category",
@@ -37,6 +55,7 @@ $additionaldomainfields[".travel"][] = array(
     "op_location" => "customerExtensionAdditionalData",
     "op_name" => "uin",
 );
+op_addConsentField($additionaldomainfields, ".travel", true);
 
 // .XXX
 $additionaldomainfields[".xxx"][] = array(
@@ -54,6 +73,7 @@ $additionaldomainfields[".xxx"][] = array(
     "op_location" => "customerExtensionAdditionalData",
     "op_name" => "defensive",
 );
+op_addConsentField($additionaldomainfields, ".xxx", true);
 
 // .JOBS
 $additionaldomainfields[".jobs"][] = array(
@@ -100,6 +120,7 @@ $additionaldomainfields[".jobs"][] = array(
     "op_location" => "customerExtensionAdditionalData",
     "op_name" => "hrMember"
 );
+op_addConsentField($additionaldomainfields, ".jobs", true);
 
 // .AERO
 $additionaldomainfields[".aero"][] = array(
@@ -119,6 +140,7 @@ $additionaldomainfields[".aero"][] = array(
     "op_location" => "customerExtensionAdditionalData",
     "op_name" => "ensKey"
 );
+op_addConsentField($additionaldomainfields, ".aero", true);
 
 // .PT
 $additionaldomainfields[".pt"][] = array(
@@ -474,6 +496,8 @@ $additionaldomainfields[".com"][] = array(
     "op_name" => "idnScript"
 );
 
+op_addConsentField($additionaldomainfields, ".com", true);
+
 // .NET
 $additionaldomainfields[".net"] = $additionaldomainfields[".com"];
 
@@ -489,6 +513,8 @@ $additionaldomainfields[".org"][] = array(
     "op_skip" => "None"
 );
 
+op_addConsentField($additionaldomainfields, ".org", true);
+
 // .VOTO
 $additionaldomainfields[".voto"][] = array(
     "Name" => "Accept Voto Registry Policy",
@@ -499,6 +525,8 @@ $additionaldomainfields[".voto"][] = array(
     "op_name" => "votoAcceptance"
 );
 
+op_addConsentField($additionaldomainfields, ".voto", true);
+
 // .VOTE
 $additionaldomainfields[".vote"][] = array(
     "Name" => "Accept Vote Registry Policy",
@@ -508,6 +536,8 @@ $additionaldomainfields[".vote"][] = array(
     "op_location" => "domainAdditionalData",
     "op_name" => "voteAcceptance"
 );
+
+op_addConsentField($additionaldomainfields, ".vote", true);
 
 // .SCOT
 $additionaldomainfields[".scot"][] = array(
@@ -537,6 +567,8 @@ $additionaldomainfields[".scot"][] = array(
     "op_location" => "domainAdditionalData",
     "op_name" => "domainNameVariants"
 );
+
+op_addConsentField($additionaldomainfields, ".scot", true);
 
 // .EUS
 $additionaldomainfields[".eus"] = $additionaldomainfields[".scot"];
@@ -600,6 +632,8 @@ $additionaldomainfields[".democrat"][] = array(
     "op_name" => "idnScript",
     "op_skip" => "None"
 );
+
+op_addConsentField($additionaldomainfields, ".democrat", true);
 
 // .DANCE
 $additionaldomainfields[".dance"] = $additionaldomainfields[".democrat"];
@@ -700,6 +734,8 @@ $additionaldomainfields[".immobilien"][] = array(
     "op_skip" => "None"
 );
 
+op_addConsentField($additionaldomainfields, ".immobilien", true);
+
 // .KAUFEN
 $additionaldomainfields[".kaufen"] = $additionaldomainfields[".immobilien"];
 
@@ -717,6 +753,8 @@ $additionaldomainfields[".nrw"][] = array(
     "op_name" => "idnScript",
     "op_skip" => "None"
 );
+
+op_addConsentField($additionaldomainfields, ".nrw", true);
 
 // .OPR (xn--c1avg)
 $additionaldomainfields[".opr"][] = array(
@@ -766,6 +804,8 @@ $additionaldomainfields[".swiss"][] = array(
     "op_name" => "intendedUse"
 );
 
+op_addConsentField($additionaldomainfields, ".swiss", true);
+
 // .RADIO
 $additionaldomainfields[".radio"][] = array(
     "Name" => "Intended Use",
@@ -775,6 +815,8 @@ $additionaldomainfields[".radio"][] = array(
     "op_location" => "domainAdditionalData",
     "op_name" => "intendedUse"
 );
+
+op_addConsentField($additionaldomainfields, ".radio", true);
 
 // .LAW
 $additionaldomainfields[".law"][] = array(
@@ -830,8 +872,10 @@ $additionaldomainfields[".law"][] = array(
     "op_location" => "domainAdditionalData",
     "op_name" => "lawAcceptance"
 );
-// .FI
 
+op_addConsentField($additionaldomainfields, ".law", true);
+
+// .FI
 $additionaldomainfields[".fi"][] = array(
     "Name" => "Organisation Type",
     "LangVar" => "fiOrgType",
@@ -841,6 +885,7 @@ $additionaldomainfields[".fi"][] = array(
     "op_name" => "orgType"
 );
 
+// .NU
 $additionaldomainfields['.nu'][] = array(
     'Name' => 'Identification Number',
     "Remove" => true,
@@ -868,6 +913,8 @@ $additionaldomainfields[".pro"][] = array(
     "Remove" => true,
 );
 
+op_addConsentField($additionaldomainfields, ".pro", true);
+
 // .TOP
 $additionaldomainfields[".top"][] = array(
     "Name" => "Internationalized domain name Script (only for IDN domains)",
@@ -879,6 +926,8 @@ $additionaldomainfields[".top"][] = array(
     "op_name" => "idnScript",
     "op_skip" => "None"
 );
+
+op_addConsentField($additionaldomainfields, ".top", true);
 
 // .EU
 $additionaldomainfields[".eu"][] = array(


### PR DESCRIPTION
feat(whmcs/openprovider): add consentForPublishing to new gTLDs

- Add `consentForPublishing` tickbox to newly covered gTLDs in
  modules/registrars/openprovider/configuration/additionalfields.php
- Default unchecked (privacy by default); label text polished for clarity