### PR TITLE
Added german language support

### DIFF
--- a/lang/overrides/german.php
+++ b/lang/overrides/german.php
@@ -9,19 +9,19 @@ $_LANG['dnssec']['activatednssecbutton']   = 'DNSSEC aktivieren';
 $_LANG['dnssec']['deactivatednssecbutton'] = 'DNSSEC deaktivieren';
 
 
-$_LANG['dnssec']['alertdnssecnotactivated'] = 'DNSSEC ist nicht aktiviert auf dieser Domain.';
-$_LANG['dnssec']['alertdnssecactivated']     = 'DNSSEC ist auf dieser Domain aktiv. Wenn DNSSEC deaktiviert wird, werden alle DNSSEC-Einträge gelöscht.';
+$_LANG['dnssec']['alertdnssecnotactivated'] = 'DNSSEC ist für diese Domain nicht aktiv.';
+$_LANG['dnssec']['alertdnssecactivated']     = 'DNSSEC ist auf dieser Domain aktiv. Wenn Sie DNSSEC deaktivieren, werden alle vorhandenen Schlüssel aus dieser Domain gelöscht.';
 
-$_LANG['dnssec']['tableheaderflags']       = 'Flag';
+$_LANG['dnssec']['tableheaderflags']       = 'Flags';
 $_LANG['dnssec']['tableheaderalgorithms']  = 'Algorithmus';
-$_LANG['dnssec']['tableheaderpublickeys'] = 'Public key';
+$_LANG['dnssec']['tableheaderpublickeys'] = 'Öffentlicher Schlüssel';
 $_LANG['dnssec']['tableheaderactions']     = 'Aktionen';
 
 
 $_LANG['dnssec']['tablebuttonactiondelete'] = 'Löschen';
 $_LANG['dnssec']['tablebuttonactionsave']   = 'Speichern';
 
-$_LANG['dnssec']['buttonadddnssecrecord'] = 'Einen neuen DNSSEC-Eintrag hinzufügen';
+$_LANG['dnssec']['buttonadddnssecrecord'] = 'Neuen DNSSEC-Eintrag hinzufügen';
 
 $_LANG['esIdentificationType'] = 'Identification Type';
 $_LANG['esIdentificationNumber'] = "Company or Individual ID";

--- a/lang/overrides/german.php
+++ b/lang/overrides/german.php
@@ -1,0 +1,36 @@
+<?php
+
+$_LANG['dnssectabname'] = 'DNSSEC Verwaltung';
+
+$_LANG['dnssec']['pagename']  = 'DNSSEC Einträge';
+$_LANG['dnssec']['tablename'] = 'DNSSEC Einträge verwalten';
+
+$_LANG['dnssec']['activatednssecbutton']   = 'DNSSEC aktivieren';
+$_LANG['dnssec']['deactivatednssecbutton'] = 'DNSSEC deaktivieren';
+
+
+$_LANG['dnssec']['alertdnssecnotactivated'] = 'DNSSEC ist nicht aktiviert auf dieser Domain.';
+$_LANG['dnssec']['alertdnssecactivated']     = 'DNSSEC ist auf dieser Domain aktiv. Wenn DNSSEC deaktiviert wird, werden alle DNSSEC-Einträge gelöscht.';
+
+$_LANG['dnssec']['tableheaderflags']       = 'Flag';
+$_LANG['dnssec']['tableheaderalgorithms']  = 'Algorithmus';
+$_LANG['dnssec']['tableheaderpublickeys'] = 'Public key';
+$_LANG['dnssec']['tableheaderactions']     = 'Aktionen';
+
+
+$_LANG['dnssec']['tablebuttonactiondelete'] = 'Löschen';
+$_LANG['dnssec']['tablebuttonactionsave']   = 'Speichern';
+
+$_LANG['dnssec']['buttonadddnssecrecord'] = 'Einen neuen DNSSEC-Eintrag hinzufügen';
+
+$_LANG['esIdentificationType'] = 'Identification Type';
+$_LANG['esIdentificationNumber'] = "Company or Individual ID";
+$_LANG['esIdentificationPassport'] = "Passport/Individual ID";
+$_LANG['esIdentificationCompany'] = "Company Registration ID";
+$_LANG['esIdentificationCORI'] = "Company or Individual ID";
+
+$_LANG['ptIdentificationType'] = 'Tipo de Contribuinte (VAT/TAX ID)';
+$_LANG['ptIdentificationNumber'] = 'Tipo de Contribuinte (VAT/TAX ID)';
+$_LANG['ptIdentificationVat'] = "NIPC (empresa)";
+$_LANG['ptIdentificationSocialSecurityNumber'] = "NIF (particular)";
+$_LANG['ptIdentificationCORI'] = 'Tipo de Contribuinte (VAT/TAX ID)';


### PR DESCRIPTION
Created a seperate file for german language overrides in `lang/overrides/german.php`. Additionally keys for spanish and portoguese language keys for tax purposes where left as is (like in the english version).