### PR TITLE
Fixed Incorrect Error Response for DomainUpdateLockingStatus in WHMCS Module

### DIFF
--- a/modules/registrars/openprovider/Controllers/System/RegistrarLockController.php
+++ b/modules/registrars/openprovider/Controllers/System/RegistrarLockController.php
@@ -81,6 +81,7 @@ class RegistrarLockController extends BaseController
             $this->apiHelper->updateDomain($domainOp['id'], [
                 'isLocked' => $params["lockenabled"] == "locked",
             ]);
+            $values["success"] = true;
         } catch (\Exception $e) {
             $values["error"] = $e->getMessage();
         }


### PR DESCRIPTION
Fixed Incorrect Error Response for DomainUpdateLockingStatus in WHMCS Module
Ensure RegistrarLockController::save() returns a proper success/error array. 
Prevents WHMCS from showing "Registrar Error Message" when lock updates succeed.