### PR TITLE
Fix : Openprovider does not filter all the additional fields in dist.additionalfield.php

### DIFF
--- a/modules/registrars/openprovider/vendor/wedevelopcoffee/wpower/src/Domain/AdditionalFields.php
+++ b/modules/registrars/openprovider/vendor/wedevelopcoffee/wpower/src/Domain/AdditionalFields.php
@@ -74,34 +74,37 @@ class AdditionalFields
     {
         // Get the distribution fields.
         $this->getDistAdditionalFields();
-        // Loop through the fields and compile a finished additional fields set.
-        $additionalField = [];
-        foreach ($this->registrarAdditionalFields as $tld => $fields) {
+        $additionalFields = [];
+
+        //Loop over all registrar TLDs 
+        foreach (array_keys((array)$this->registrarTlds) as $tld) {
+
+            // Use custom fields if present; otherwise empty array
+            $fields = $this->registrarAdditionalFields[$tld] ?? [];
+
+            // Set the additional fields.
+            $additionalFields[$tld] = $fields;
+
             $tmpRegistrarFields = [];
-            // Only override TLDs that belong to this registrar.
-            if (isset($this->registrarTlds[$tld])) {
-                // Set the additional fields.
-                $additionalFields[$tld] = $fields;
-                // Temporarily store the field names to prevent that they will get removed from WHMCS.
-                foreach ($fields as $field) {
-                    $tmpRegistrarFields[$field['Name']] = true;
-                }
-                // Remove the distributed fields.
-                if (isset($this->distAdditionalFields[$tld])) {
-                    // Disable the additional fields.
-                    foreach ($this->distAdditionalFields[$tld] as $whmcsField) {
-                        if (!is_array($whmcsField)) {
-                            $name = $whmcsField;
-                            $whmcsField = array();
-                            $whmcsField['Name'] = $name;
-                        }
-                        // Only remove fields that are not in the Registrars field.
-                        if (!isset($tmpRegistrarFields[$whmcsField['Name']])) {
-                            $removeField = [];
-                            $removeField['Name']    = $whmcsField['Name'];
-                            $removeField['Remove']  = true;
-                            $additionalFields[$tld][] = $removeField;
-                        }
+            // Temporarily store the field names to prevent that they will get removed from WHMCS.
+            foreach ($fields as $field) {
+                $tmpRegistrarFields[$field['Name']] = true;
+            }
+            // Remove the distributed fields.
+            if (isset($this->distAdditionalFields[$tld])) {
+                // Disable the additional fields.
+                foreach ($this->distAdditionalFields[$tld] as $whmcsField) {
+                    if (!is_array($whmcsField)) {
+                        $name = $whmcsField;
+                        $whmcsField = array();
+                        $whmcsField['Name'] = $name;
+                    }
+                    // Only remove fields that are not in the Registrars field.
+                    if (!isset($tmpRegistrarFields[$whmcsField['Name']])) {
+                        $removeField = [];
+                        $removeField['Name']    = $whmcsField['Name'];
+                        $removeField['Remove']  = true;
+                        $additionalFields[$tld][] = $removeField;
                     }
                 }
             }


### PR DESCRIPTION
Updated getFilteredAdditionalFields() to iterate all registrar TLDs and use our custom fields if present.
For TLDs with no custom fields, add ['Name' => ..., 'Remove' => true] for each dist field, hiding them from UI.