### PR TITLE
Fix: getEPPCode() fails for .BE domains (TypeError: Return value must be of type string)

### DIFF
--- a/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
+++ b/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
@@ -70,6 +70,11 @@ class ApiHelper
                 return $result['authCode'];
             }
 
+            if ($result['success'] == true) {
+                $message = "The authorization code has been successfully sent to the registrant email. Please check registrant inbox.";
+                return $message;
+            }
+
             if (isset($result['message']) && $result['message'] != "") {
                 throw new \Exception($result['message']);
             }


### PR DESCRIPTION
Handled the .BE flow in getEPPCode() by returning a success message, when the API responds `success=true` with no authCode, preventing the TypeError.