### PR TITLE
Fix confirmation prompt in update_openprovider.sh

### DIFF
--- a/scripts/update_openprovider.sh
+++ b/scripts/update_openprovider.sh
@@ -17,7 +17,7 @@ fi
 # Prompt user for confirmation to proceed with the update
 if [ -r /dev/tty ]; then
     read -u 3 -p "Important: Updating the Openprovider module may overwrite any custom modifications you've made. Do you want to proceed? (Y/n): " confirm 3</dev/tty
-    if [[ -z "$confirm" || "$confirm" =~ ^[Yy]$ ]]; then
+    if [[ "$confirm" =~ ^[Yy]$ ]]; then
         echo "Proceeding with the update..."
     else
         echo "Update canceled. Please backup your customizations before proceeding."


### PR DESCRIPTION
Used read -u 3 with /dev/tty to read input directly from the interactive terminal to ensure the confirmation prompt works when running the script via curl | bash.
