### PR TITLE
Fix "warning" in balance widget when reserved balance was 4 digits

### DIFF
--- a/modules/registrars/openprovider/Controllers/Hooks/Widgets/BalanceWidget.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/Widgets/BalanceWidget.php
@@ -138,13 +138,14 @@ EOF;
         }
         $availableBalance = $data['balance'] - $data['reservedBalance'];
         $balance = number_format((float) $data['balance'], 2);
-        $availableBalance = number_format((float) $availableBalance, 2);
 
         if ($data['balance'] <= 100)
             $balance_css = 'text-danger';
 
         if ($availableBalance <= 100)
             $reservedBalance_css = 'text-danger';
+
+        $availableBalance = number_format((float) $availableBalance, 2);
 
 
         return <<<EOF


### PR DESCRIPTION
When the reserved balance hit 4 digits (fx 1000,00€), the widget would apply "text danger" to the reserved balance. We were comparing the formatted number (1,000.00) instead of the float.