### PR TITLE
Fix: Registrar lock still showing for non english languages

### DIFF
--- a/modules/registrars/openprovider/Controllers/Hooks/DomainLockingEnabledController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/DomainLockingEnabledController.php
@@ -50,8 +50,10 @@ class DomainLockingEnabledController
         }
 
         $unlockedLabel = \Lang::trans('domaincurrentlyunlocked');
+        if (empty($unlockedLabel)) {
+            $unlockedLabel = 'Domain Currently Unlocked!';
+        }
         $unlockedLabelJs = json_encode($unlockedLabel);
-    
         return '
                 <script>
                 document.addEventListener("DOMContentLoaded", function() {


### PR DESCRIPTION
Replaced the hard coded string check with a language independent detection method for removing alert.