### PR TITLE
Support WHMCS theme override for DNSSEC template with fallback

### DIFF
--- a/modules/registrars/openprovider/Controllers/System/DnssecPageController.php
+++ b/modules/registrars/openprovider/Controllers/System/DnssecPageController.php
@@ -141,8 +141,6 @@ class DnssecPageController extends BaseController
         }
 
         $activeTheme = Setting::getValue('Template');
-
-        // Sanitize theme name (defense-in-depth)
         $activeTheme = preg_replace('/[^a-zA-Z0-9_-]/', '', (string) $activeTheme);
 
         // Default to module fallback template
@@ -152,10 +150,8 @@ class DnssecPageController extends BaseController
         $templatesDirReal = realpath($templatesDir);
 
         if ($templatesDirReal !== false && $activeTheme !== '') {
-            $candidate = $templatesDir . '/' . $activeTheme . '/dnssec.tpl';
+            $candidate = $templatesDirReal . '/' . $activeTheme . '/dnssec.tpl';
             $resolved = realpath($candidate);
-
-            // realpath() only works if the file exists; if it exists, no need to call file_exists again.
             if ($resolved !== false && str_starts_with($resolved, $templatesDirReal . DIRECTORY_SEPARATOR)) {
                 $template = 'dnssec';
             }


### PR DESCRIPTION
Updated the DNSSEC client-area page to use a theme template when available, with a fallback to the existing module-bundled template.