### PR TITLE
Fix Whmcs domain locking enabled controller fires on non domain pages

### DIFF
--- a/modules/registrars/openprovider/Controllers/Hooks/DomainLockingEnabledController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/DomainLockingEnabledController.php
@@ -126,6 +126,9 @@ class DomainLockingEnabledController
 
     private function isDomainLockingEnabled(Domain $domain): bool
     {
+        if (!in_array($domain->status, ['Active', 'Pending Transfer'], true)) {
+            return false;
+        }
         try {
             $op_domain_obj = DomainFullNameToDomainObject::convert($domain->domain);
             $lockable_state = Cache::get($op_domain_obj->extension);


### PR DESCRIPTION
Based on fixes given by the user in issue [#469](https://github.com/openprovider/Openprovider-WHMCS-domains/issues/469), updated and tested the flow to ensure DomainLockingEnabledController::handleDomainLockingClientSidebar() only fires on the domain details page.