### PR TITLE
Return success on sucessful domain renewal/restore

### DIFF
--- a/modules/registrars/openprovider/Controllers/System/RenewDomainController.php
+++ b/modules/registrars/openprovider/Controllers/System/RenewDomainController.php
@@ -59,8 +59,6 @@ class RenewDomainController extends BaseController
             } catch (\Exception $e) {
                 return ['error' => $e->getMessage()];
             }
-
-            return [];
         }
 
         // If isInRedemptionGracePeriod is true, restore the domain.
@@ -72,8 +70,6 @@ class RenewDomainController extends BaseController
             } catch (\Exception $e) {
                 return ['error' => $e->getMessage()];
             }
-
-            return [];
         }
 
         // We did not have a true isInRedemptionGracePeriod or isInGracePeriod. Fall back on the legacy code
@@ -95,6 +91,6 @@ class RenewDomainController extends BaseController
             return ['error' => $e->getMessage()];
         }
 
-        return [];
+        return ['success' => true];
     }
 }


### PR DESCRIPTION
When a domain renewal is successful, it's required to return `'success' => true`, otherwise WHMCS doesn't send the admin email template "Domain Renewal Successful".