### PR TITLE
Fix: Dns txt record not showing in whmcs client area

### DIFF
--- a/modules/registrars/openprovider/Controllers/System/DnsManagementPageController.php
+++ b/modules/registrars/openprovider/Controllers/System/DnsManagementPageController.php
@@ -89,10 +89,10 @@ class DnsManagementPageController extends BaseController
             }
 
             try {
-                $hostname = trim((string)($_POST['hostname'] ?? '')); // "www" or ""
-                $type     = strtoupper(trim((string)($_POST['type'] ?? '')));
-                $address  = trim((string)($_POST['address'] ?? ''));
-                $priority = trim((string)($_POST['priority'] ?? ''));
+                $hostname = html_entity_decode(trim((string) ($_POST['hostname'] ?? '')), ENT_QUOTES, 'UTF-8');
+                $type     = strtoupper(trim((string) ($_POST['type'] ?? '')));
+                $address  = html_entity_decode(trim((string) ($_POST['address'] ?? '')), ENT_QUOTES, 'UTF-8');
+                $priority = html_entity_decode(trim((string) ($_POST['priority'] ?? '')), ENT_QUOTES, 'UTF-8');
 
                 if ($type === '' || $address === '') {
                     http_response_code(400);
@@ -300,10 +300,10 @@ class DnsManagementPageController extends BaseController
         $priority  = $_POST['dnsrecordpriority'] ?? [];
 
         foreach ($hosts as $i => $host) {
-            $host    = trim((string)$host);
-            $type    = strtoupper(trim((string)($types[$i] ?? '')));
-            $address = trim((string)($addresses[$i] ?? ''));
-            $prio    = trim((string)($priority[$i] ?? ''));
+            $host    = html_entity_decode(trim((string) $host), ENT_QUOTES, 'UTF-8');
+            $type    = strtoupper(trim((string) ($types[$i] ?? '')));
+            $address = html_entity_decode(trim((string) ($addresses[$i] ?? '')), ENT_QUOTES, 'UTF-8');
+            $prio    = html_entity_decode(trim((string) ($priority[$i] ?? '')), ENT_QUOTES, 'UTF-8');
 
             // Skip completely empty rows
             if ($host === '' && $address === '') {

--- a/modules/registrars/openprovider/includes/templates/dnsmanagement.tpl
+++ b/modules/registrars/openprovider/includes/templates/dnsmanagement.tpl
@@ -32,7 +32,7 @@
                     <tbody>
                         {foreach $dnsrecords as $dnsrecord}
                             <tr>
-                                <td><input type="hidden" name="dnsrecid[]" value="{$dnsrecord.recid}" /><input type="text" name="dnsrecordhost[]" value="{$dnsrecord.hostname}" size="10" class="form-control" /></td>
+                                <td><input type="hidden" name="dnsrecid[]" value="{$dnsrecord.recid|escape:'html'}" /><input type="text" name="dnsrecordhost[]" value="{$dnsrecord.hostname|escape:'html'}" size="10" class="form-control" /></td>
                                 <td>
                                     <select name="dnsrecordtype[]" class="form-control">
                                         <option value="A"{if $dnsrecord.type eq "A"} selected="selected"{/if}>{lang key="domainDns.a"}</option>
@@ -45,9 +45,9 @@
                                         <option value="FRAME"{if $dnsrecord.type eq "FRAME"} selected="selected"{/if}>{lang key="domainDns.frame"}</option>
                                     </select>
                                 </td>
-                                <td><input type="text" name="dnsrecordaddress[]" value="{$dnsrecord.address}" size="40" class="form-control" /></td>
+                                <td><input type="text" name="dnsrecordaddress[]" value="{$dnsrecord.address|escape:'html'}" size="40" class="form-control" /></td>
                                 <td>
-                                    {if $dnsrecord.type eq "MX"}<input type="text" name="dnsrecordpriority[]" value="{$dnsrecord.priority}" size="2" class="form-control" />{else}<input type="hidden" name="dnsrecordpriority[]" value="N/A" />{lang key='domainregnotavailable'}{/if}
+                                    {if $dnsrecord.type eq "MX"}<input type="text" name="dnsrecordpriority[]" value="{$dnsrecord.priority|escape:'html'}" size="2" class="form-control" />{else}<input type="hidden" name="dnsrecordpriority[]" value="N/A" />{lang key='domainregnotavailable'}{/if}
                                 </td>
                                 <td class="text-center">
                                     <button type="button"


### PR DESCRIPTION
- Fixed TXT records displaying empty and being double-encoded on save
