### PR TITLE
Add global caching for getTldMeta() API calls

### DIFF
--- a/modules/registrars/openprovider/Controllers/System/ContactController.php
+++ b/modules/registrars/openprovider/Controllers/System/ContactController.php
@@ -14,7 +14,6 @@ use WeDevelopCoffee\wPower\Core\Core;
 use WHMCS\Database\Capsule;
 
 use OpenProvider\WhmcsRegistrar\helpers\Dictionary;
-use OpenProvider\WhmcsRegistrar\helpers\DbCacheHelper;
 
 /**
  * Class ContactControllerView
@@ -34,8 +33,6 @@ class ContactController extends BaseController
      * @var ApiHelper
      */
     private $apiHelper;
-
-    private const TLD_METADATA_CACHE_TTL = 60 * 60 * 24; // 24 hours (in seconds)
 
     /**
      * ConfigController constructor.
@@ -235,14 +232,7 @@ class ContactController extends BaseController
             return [];
         }
 
-        $mode = ($params['test_mode'] ?? false) === 'on' ? 'test' : 'live';
-
-        $tldMetaData = DbCacheHelper::remember(
-            'tld_meta_' . $this->domain->extension,
-            $mode,
-            self::TLD_METADATA_CACHE_TTL,
-            fn() => $this->apiHelper->getTldMeta($this->domain->extension)
-        );
+        $tldMetaData = $this->apiHelper->getTldMeta($this->domain->extension);
 
         $handlesToFetch = [];
         foreach (APIConfig::$handlesNames as $key => $name) {

--- a/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
+++ b/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
@@ -6,6 +6,7 @@ use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use WeDevelopCoffee\wPower\Models\Domain as DomainModel;
 use GuzzleHttp6\Promise\Utils;
+use OpenProvider\WhmcsRegistrar\helpers\DbCacheHelper;
 
 class ApiHelper
 {
@@ -22,6 +23,9 @@ class ApiHelper
      * ApiManager constructor.
      * @param ApiInterface $apiClient
      */
+
+    private const TLD_METADATA_CACHE_TTL = 60 * 60 * 24; // 24 hours
+
     public function __construct(ApiInterface $apiClient)
     {
         $this->apiClient = $apiClient;
@@ -697,9 +701,15 @@ class ApiHelper
         if ($tld === '') {
             throw new \InvalidArgumentException('Missing TLD.');
         }
-        
-        return $this->buildResponse(
-            $this->apiClient->call('retrieveExtensionRequest', ['name' => $tld])
+
+        $mode = defined('MODE') ? MODE : 'live'; 
+        return DbCacheHelper::remember(
+            'tld_meta_' . strtolower($tld),
+            $mode,
+            self::TLD_METADATA_CACHE_TTL,
+            fn() => $this->buildResponse(
+                $this->apiClient->call('retrieveExtensionRequest', ['name' => $tld])
+            )
         );
     }
 

--- a/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
+++ b/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
@@ -697,7 +697,7 @@ class ApiHelper
      */
     public function getTldMeta(string $tld): array
     {
-        $tld = trim($tld);
+        $tld = ltrim(strtolower(trim($tld)), '.');
         if ($tld === '') {
             throw new \InvalidArgumentException('Missing TLD.');
         }
@@ -706,7 +706,7 @@ class ApiHelper
         $mode = str_contains($host, 'sandbox') ? 'test' : 'live';
     
         return DbCacheHelper::remember(
-            'tld_meta_' . strtolower($tld),
+            'tld_meta_' . $tld,
             $mode,
             self::TLD_METADATA_CACHE_TTL,
             fn() => $this->buildResponse(

--- a/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
+++ b/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
@@ -702,7 +702,9 @@ class ApiHelper
             throw new \InvalidArgumentException('Missing TLD.');
         }
 
-        $mode = defined('MODE') ? MODE : 'live'; 
+        $host = $this->apiClient->getConfiguration()->getHost();
+        $mode = str_contains($host, 'sandbox') ? 'test' : 'live';
+    
         return DbCacheHelper::remember(
             'tld_meta_' . strtolower($tld),
             $mode,


### PR DESCRIPTION
- Added global caching in ApiHelper::getTldMeta() to reduce repeated retrieveExtensionRequest calls
- Removed redundant controller-level caching to centralize logic