### PR TITLE
fix(transfer): accept external nameservers without registry validation (#525)

### DIFF
--- a/modules/registrars/openprovider/OpenProvider/API/APITools.php
+++ b/modules/registrars/openprovider/OpenProvider/API/APITools.php
@@ -11,11 +11,33 @@ namespace OpenProvider\API;
 
 class APITools
 {
+    /**
+     * Build a list of DomainNameServer objects from the WHMCS-supplied
+     * ns1..ns5 params for register / transfer / save flows.
+     *
+     * Nameserver IPs are only required for *in-bailiwick* glue records
+     * (NS that are the apex domain itself or a subdomain of the domain
+     * being registered/transferred). For all other (out-of-bailiwick)
+     * nameservers, Openprovider does not require an IP and the module
+     * must not gate inclusion on DNS resolution — doing so silently
+     * dropped customer-supplied external NS, and the registry then
+     * substituted reseller defaults at the moment of transfer, causing
+     * silent DNS outages (see issue #525).
+     *
+     * @param array $params      WHMCS module params; must contain sld, tld,
+     *                           and ns1..ns5 (each ns may be in "name" or
+     *                           "name/ip" form).
+     * @param mixed $apiHelper   Optional ApiHelper for resolving
+     *                           glue-record IPs from the registry.
+     * @return DomainNameServer[]
+     * @throws \Exception When fewer than 2 nameservers are supplied, or a
+     *                    glue record lacks an IP that cannot be resolved.
+     */
     public static function createNameserversArray($params, $apiHelper = null)
     {
         $nameServers = array();
 
-        //can be used to hard-code a nameserver overwrite when using the DNS management addon 
+        //can be used to hard-code a nameserver overwrite when using the DNS management addon
         // if($params['dnsmanagement'] == true)
         // {
         //     $params['ns1'] = 'ns1.openprovider.nl';
@@ -25,102 +47,115 @@ class APITools
         //     $params['ns5'] = null;
         // }
 
-        if ($params['test_mode'] == 'on' && $apiHelper != null) {
-            
-            for ($i = 1; $i <= 5; $i++) {
-                $ns = $params["ns{$i}"];
-                if (!$ns) {
-                    continue;
-                }
-                $nsParts = explode('/', $ns);
-                $nsName = trim($nsParts[0]);
-                $nsIp = empty($nsParts[1]) ? null : trim($nsParts[1]);
+        $domainFqdn = strtolower(
+            ($params['sld'] ?? '') . (isset($params['tld']) ? '.' . $params['tld'] : '')
+        );
+        $domainFqdn = trim($domainFqdn, '.');
 
-                //Try to get IP from searchNsRequest in REST API
-                if (empty($nsIp)) {
-                    $myNameServerList = $apiHelper->getNameserverList($nsName);
-                    foreach ($myNameServerList as $myNameServer) {
-                        if ($myNameServer->name == $nsName) {
-                            $nsIp = $myNameServer->ip;
-                            break;
-                        }
-                    }
-                }
-
-                // Try to get IP from gethostbyName
-                if (empty($nsIp)) {
-                    $nsIp = gethostbyname($nsName);
-                    if (!filter_var($nsIp, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
-                        $nsIp = "";
-                        throw new \Exception("Invalid nameserver name: {$nsName}");
-                    }
-                }                
-
-                if (!empty($nsIp) && !empty($nsName)) {
-                    $nameServers[] = new \OpenProvider\API\DomainNameServer(array(
-                        'name'  =>  $nsName,
-                        'ip'    =>  $nsIp
-                    ));
-                }
-            }
-
-            if (count($nameServers) < 2) {
-                throw new \Exception('You must enter minimum 2 nameservers');
-            }
-
-            return $nameServers;
-        }
-
-        $invalidNameServer = false;
         for ($i = 1; $i <= 5; $i++) {
-            $ns = $params["ns{$i}"];
+            $ns = $params["ns{$i}"] ?? null;
             if (!$ns) {
                 continue;
             }
 
             $nsParts = explode('/', $ns);
-            $nsName = trim($nsParts[0]);
-            $nsIp = empty($nsParts[1]) ? null : trim($nsParts[1]);
+            $nsName  = strtolower(trim($nsParts[0]));
+            $nsIp    = empty($nsParts[1]) ? null : trim($nsParts[1]);
 
-            if (empty($nsIp)) {
-                $api = new \OpenProvider\API\API();
-                $api->setParams($params);
-                $searchResult = $api->sendRequest('searchNsRequest', array(
-                    'pattern' => $nsName,
-                ));
+            if ($nsName === '') {
+                continue;
+            }
 
-                if ($searchResult['total'] > 0) {
-                    $nsIp = $searchResult['results'][0]['ip'];
+            if (self::isGlueRecord($nsName, $domainFqdn) && empty($nsIp)) {
+                // In-bailiwick NS — IP is mandatory at the registry. Try
+                // the Openprovider registry first, then DNS resolution as
+                // a fallback. Throw if neither produces a valid IPv4 so the
+                // user sees the problem instead of silent reseller defaults.
+                $nsIp = self::resolveGlueIp($nsName, $params, $apiHelper);
+
+                if (empty($nsIp)) {
+                    throw new \Exception(
+                        "Nameserver {$nsName} is in-bailiwick (a glue record) "
+                        . "but no IP could be resolved. Please supply it "
+                        . "explicitly in the form 'name/ip'."
+                    );
                 }
             }
 
-            //Try to get IP from gethostbyName
-            if (empty($nsIp)) {
-                $nsIp = gethostbyname($nsName);
-                if (!filter_var($nsIp, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
-                    $nsIp = "";
-                    $invalidNameServer = true;
-                    logModuleCall('openprovider', 'createNameserversArray', $nsName, "Invalid nameserver name: {$nsName}", null, null);
-                }
+            $attrs = ['name' => $nsName];
+            if (!empty($nsIp)) {
+                $attrs['ip'] = $nsIp;
             }
 
-            if (!empty($nsIp) && !empty($nsName)) {
-                $nameServers[] = new \OpenProvider\API\DomainNameServer(array(
-                    'name'  =>  $nsName,
-                    'ip'    =>  $nsIp
-                ));
-            }
+            $nameServers[] = new \OpenProvider\API\DomainNameServer($attrs);
         }
 
         if (count($nameServers) < 2) {
-            if($invalidNameServer) {
-                throw new \Exception('You must enter minimum 2 nameservers. Invalid nameserver found. Please check the module log.');
-            }else{
-                throw new \Exception('You must enter minimum 2 nameservers');
-            }            
+            throw new \Exception('You must enter minimum 2 nameservers');
         }
 
         return $nameServers;
+    }
+
+    /**
+     * A nameserver is a glue record if it is the apex domain itself or a
+     * subdomain of the domain being registered/transferred.
+     */
+    private static function isGlueRecord(string $nsName, string $domainFqdn): bool
+    {
+        if ($domainFqdn === '' || $nsName === '') {
+            return false;
+        }
+
+        return $nsName === $domainFqdn
+            || str_ends_with($nsName, '.' . $domainFqdn);
+    }
+
+    /**
+     * Resolve a glue-record IPv4. First tries the Openprovider registry
+     * (REST via $apiHelper, otherwise the legacy XML API), then falls back
+     * to gethostbyname(). Returns null when no valid IPv4 could be found.
+     */
+    private static function resolveGlueIp(string $nsName, array $params, $apiHelper = null): ?string
+    {
+        // Prefer the REST helper when available.
+        if ($apiHelper !== null && method_exists($apiHelper, 'getNameserverList')) {
+            try {
+                $list = $apiHelper->getNameserverList($nsName);
+                foreach ((array) $list as $entry) {
+                    if (isset($entry->name) && $entry->name === $nsName && !empty($entry->ip)) {
+                        return $entry->ip;
+                    }
+                }
+            } catch (\Throwable $e) {
+                // Fall through.
+            }
+        }
+
+        // Legacy XML API path (still used by some flows).
+        try {
+            $api = new \OpenProvider\API\API();
+            $api->setParams($params);
+            $searchResult = $api->sendRequest('searchNsRequest', [
+                'pattern' => $nsName,
+            ]);
+            if (!empty($searchResult['total']) && !empty($searchResult['results'][0]['ip'])) {
+                return $searchResult['results'][0]['ip'];
+            }
+        } catch (\Throwable $e) {
+            // Fall through.
+        }
+
+        // DNS resolution fallback.
+        $resolved = @gethostbyname($nsName);
+        if ($resolved !== false
+            && $resolved !== $nsName
+            && filter_var($resolved, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)
+        ) {
+            return $resolved;
+        }
+
+        return null;
     }
 
     /*

--- a/modules/registrars/openprovider/tests/API/APIToolsTest.php
+++ b/modules/registrars/openprovider/tests/API/APIToolsTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace OpenProvider\WhmcsRegistrar\Tests\API;
+
+use Mockery;
+use OpenProvider\API\APITools;
+use OpenProvider\API\DomainNameServer;
+use OpenProvider\WhmcsRegistrar\Tests\TestCase;
+
+/**
+ * Class APIToolsTest
+ *
+ * Regression tests for issue #525: transferDomain silently replaced
+ * external nameservers with module defaults because
+ * APITools::createNameserversArray gated NS inclusion on IP resolution.
+ *
+ * @package OpenProvider\WhmcsRegistrar\Tests\API
+ */
+class APIToolsTest extends TestCase
+{
+    /**
+     * Base params shape used by createNameserversArray. Tests override only
+     * the keys they care about.
+     */
+    private function baseParams(array $overrides = []): array
+    {
+        return array_merge([
+            'sld'       => 'example',
+            'tld'       => 'com',
+            'test_mode' => 'off',
+            'ns1'       => null,
+            'ns2'       => null,
+            'ns3'       => null,
+            'ns4'       => null,
+            'ns5'       => null,
+        ], $overrides);
+    }
+
+    /**
+     * Regression test for issue #525.
+     *
+     * External (out-of-bailiwick) nameservers must be accepted by name
+     * alone. The function must NOT call gethostbyname or the registry to
+     * decide whether to include them, and it must NOT silently drop them.
+     */
+    public function test_external_nameservers_are_accepted_without_ip_lookup()
+    {
+        $params = $this->baseParams([
+            'ns1' => 'ns1.cloudflare.com',
+            'ns2' => 'ns2.cloudflare.com',
+        ]);
+
+        $apiHelper = Mockery::mock();
+        // The fix must not consult the registry for non-glue NS.
+        $apiHelper->shouldNotReceive('getNameserverList');
+
+        $result = APITools::createNameserversArray($params, $apiHelper);
+
+        $this->assertCount(2, $result);
+        $this->assertContainsOnlyInstancesOf(DomainNameServer::class, $result);
+        $this->assertSame('ns1.cloudflare.com', $result[0]->name);
+        $this->assertSame('ns2.cloudflare.com', $result[1]->name);
+        $this->assertNull($result[0]->ip);
+        $this->assertNull($result[1]->ip);
+    }
+
+    /**
+     * When the user provides "name/ip" the IP must be preserved on the
+     * resulting object — both for glue and non-glue records.
+     */
+    public function test_explicit_ip_in_name_slash_ip_form_is_preserved()
+    {
+        $params = $this->baseParams([
+            'ns1' => 'ns1.example.com/192.0.2.10',
+            'ns2' => 'ns2.example.com/192.0.2.11',
+        ]);
+
+        $result = APITools::createNameserversArray($params);
+
+        $this->assertCount(2, $result);
+        $this->assertSame('ns1.example.com', $result[0]->name);
+        $this->assertSame('192.0.2.10', $result[0]->ip);
+        $this->assertSame('ns2.example.com', $result[1]->name);
+        $this->assertSame('192.0.2.11', $result[1]->ip);
+    }
+
+    /**
+     * Glue records (NS that are subdomains of the registered/transferred
+     * domain) require an IP. When none is supplied AND none can be
+     * resolved, the function must throw with a clear message instead of
+     * silently dropping the NS — the symptom that caused issue #525.
+     */
+    public function test_glue_record_without_resolvable_ip_throws()
+    {
+        $params = $this->baseParams([
+            'sld' => 'example',
+            'tld' => 'invalid', // .invalid is reserved and unresolvable
+            'ns1' => 'ns1.example.invalid',
+            'ns2' => 'ns2.example.invalid',
+        ]);
+
+        $apiHelper = Mockery::mock();
+        $apiHelper->shouldReceive('getNameserverList')->andReturn([]);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches('/in-bailiwick \(a glue record\)/');
+
+        APITools::createNameserversArray($params, $apiHelper);
+    }
+
+    /**
+     * Glue records with a registry hit must use the registry IP without
+     * falling back to gethostbyname.
+     */
+    public function test_glue_record_uses_registry_ip_when_available()
+    {
+        $params = $this->baseParams([
+            'sld' => 'example',
+            'tld' => 'com',
+            'ns1' => 'ns1.example.com',
+            'ns2' => 'ns2.example.com',
+        ]);
+
+        $apiHelper = Mockery::mock();
+        $apiHelper->shouldReceive('getNameserverList')
+            ->with('ns1.example.com')
+            ->once()
+            ->andReturn([(object) ['name' => 'ns1.example.com', 'ip' => '192.0.2.10']]);
+        $apiHelper->shouldReceive('getNameserverList')
+            ->with('ns2.example.com')
+            ->once()
+            ->andReturn([(object) ['name' => 'ns2.example.com', 'ip' => '192.0.2.11']]);
+
+        $result = APITools::createNameserversArray($params, $apiHelper);
+
+        $this->assertCount(2, $result);
+        $this->assertSame('192.0.2.10', $result[0]->ip);
+        $this->assertSame('192.0.2.11', $result[1]->ip);
+    }
+
+    /**
+     * Empty ns slots (the user only filled ns1) must still raise the
+     * minimum-2-nameservers error.
+     */
+    public function test_throws_when_fewer_than_two_nameservers_supplied()
+    {
+        $params = $this->baseParams([
+            'ns1' => 'ns1.cloudflare.com',
+        ]);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('You must enter minimum 2 nameservers');
+
+        APITools::createNameserversArray($params);
+    }
+
+    /**
+     * Mixed list (one external, one glue with IP) must round-trip
+     * correctly.
+     */
+    public function test_mixed_glue_and_external_nameservers()
+    {
+        $params = $this->baseParams([
+            'sld' => 'example',
+            'tld' => 'com',
+            'ns1' => 'ns1.example.com/192.0.2.10', // glue, with IP
+            'ns2' => 'ns2.cloudflare.com',         // external, no IP
+        ]);
+
+        $result = APITools::createNameserversArray($params);
+
+        $this->assertCount(2, $result);
+        $this->assertSame('ns1.example.com', $result[0]->name);
+        $this->assertSame('192.0.2.10', $result[0]->ip);
+        $this->assertSame('ns2.cloudflare.com', $result[1]->name);
+        $this->assertNull($result[1]->ip);
+    }
+
+    /**
+     * Nameserver names are normalised to lowercase to match how
+     * Openprovider keys glue records.
+     */
+    public function test_nameserver_names_are_lowercased()
+    {
+        $params = $this->baseParams([
+            'ns1' => 'NS1.Cloudflare.COM',
+            'ns2' => 'NS2.CLOUDFLARE.com',
+        ]);
+
+        $result = APITools::createNameserversArray($params);
+
+        $this->assertSame('ns1.cloudflare.com', $result[0]->name);
+        $this->assertSame('ns2.cloudflare.com', $result[1]->name);
+    }
+}


### PR DESCRIPTION
Fixes #525.

## Problem

`APITools::createNameserversArray` gated nameserver inclusion on the ability to resolve an IP for **every** NS — first via Openprovider's `searchNsRequest` registry lookup, then via `gethostbyname`. For out-of-bailiwick nameservers (the vast majority of real-world cases — `ns1.cloudflare.com`, `dns.google`, etc.) neither path is appropriate: the registry lookup is for glue records only, and `gethostbyname` can fail or return the input unchanged. When that happened the NS was silently dropped from the array, the truncated list was passed to `transferDomainRequest`, and the registry substituted the reseller's default nameservers — silently changing customer DNS delegation at the moment of transfer, with no exception or warning.

## Fix

Scope IP resolution to **in-bailiwick glue records** only — i.e. NS that are the apex domain itself or a subdomain of the domain being registered/transferred. Out-of-bailiwick NS are now accepted by name alone and serialized without an `ip` field. Glue records still try the registry first, then DNS resolution; if neither produces a valid IPv4 the function throws with a clear message instead of dropping the NS.

The two code paths in the original (`test_mode == 'on'` and the default branch) collapsed into one because their differences were incidental to the fix and the new path is a strict superset.

## Changes

- `OpenProvider/API/APITools.php` — `createNameserversArray` rewritten; two new private helpers `isGlueRecord` and `resolveGlueIp` extracted.
- `tests/API/APIToolsTest.php` — new PHPUnit cases:
  - `test_external_nameservers_are_accepted_without_ip_lookup` — the direct regression test for #525; asserts `apiHelper::getNameserverList` is **not** called for non-glue NS.
  - `test_explicit_ip_in_name_slash_ip_form_is_preserved`
  - `test_glue_record_without_resolvable_ip_throws`
  - `test_glue_record_uses_registry_ip_when_available`
  - `test_throws_when_fewer_than_two_nameservers_supplied`
  - `test_mixed_glue_and_external_nameservers`
  - `test_nameserver_names_are_lowercased`

## Risk / verification

- `DomainNameServer::$ip` already defaults to `null`, so omitting the key from the constructor array leaves the property null. The Symfony `PropertyNormalizer` used by `ApiHelper` will emit `ip: null` for external NS in the request body. If, in review, we'd rather suppress the null entirely, the smallest follow-up is to make `DomainNameServer` implement `JsonSerializable` and skip null fields — happy to add that in this PR if reviewers prefer.
- All three callers (`DomainController::transfer`, `DomainController::register`, `NameserverController::saveNameservers`) use the return value as-is — no caller-side changes required.
- PHP floor in `composer.json` resolves to >= 8.1 (per `vendor/composer/platform_check.php`), so `str_ends_with` is available natively.

## Test plan

- [ ] CI passes (PHPUnit + lint).
- [ ] Manual: transfer a domain with external NS (e.g. Cloudflare) and confirm the registry receives those NS — not the reseller defaults.
- [ ] Manual: transfer a domain using glue NS (`ns1.<being-transferred>.tld`) with explicit `name/ip` and confirm IP is preserved.
- [ ] Manual: attempt transfer with glue NS missing IP and unresolvable hostname; confirm a clear error surfaces in WHMCS instead of a silent default-substitution.
