### PR TITLE
Adding new contacts with required customerAdditionalData

### DIFF
--- a/docs/advanced_configurations.md
+++ b/docs/advanced_configurations.md
@@ -17,7 +17,7 @@ Advanced configurations can be found in the file `/modules/registrars/openprovid
 | useNewDnsManagerFeature         | boolean: false                             | Set to true to enable the Openprovider [single domain DNS panel](https://support.openprovider.eu/hc/en-us/articles/360014539999-Single-Domain-DNS-panel) for your customers who you have given the right to edit DNS zones for their domain. |
 | useNewDnsManagerFeatureInNewWindow | boolean: true                             | When this option is enabled, the DNS Manager will open in a new window. This requires the "useNewDnsManagerFeature" configuration to be enabled. |
 | requestTrusteeService           | array: ["ba","co.uk"]                      | Indicates which TLDs will automatically have the trustee option selected upon registration. |
-| idnumbermod                     | boolean: false                             | Indicates whether to use the [advanced additional data handling for .es and .pt domains](/docs/advanced_additional_data.md) |
+| idnumbermod                     | boolean: true                              | Indicates whether to enable [advanced customer additional data handling for .es, .pt, .se, .com.es, .nom.es, .edu.es, .org.es, .it and .fi domains](/docs/advanced_additional_data.md) |
 
 
 

--- a/lang/overrides/english.php
+++ b/lang/overrides/english.php
@@ -35,3 +35,14 @@ $_LANG['ptIdentificationNumber'] = 'Tipo de Contribuinte (VAT/TAX ID)';
 $_LANG['ptIdentificationVat'] = "NIPC (empresa)";
 $_LANG['ptIdentificationSocialSecurityNumber'] = "NIF (particular)";
 $_LANG['ptIdentificationCORI'] = 'Tipo de Contribuinte (VAT/TAX ID)';
+
+$_LANG['itIdentificationCompany'] = 'Company Registration Number';
+$_LANG['itIdentificationSocialSecurityNumber'] = 'Individual Codice Fiscale';
+
+$_LANG['seIdentificationCompany'] = 'Legal Entity';
+$_LANG['seIdentificationSocialSecurityNumber'] = 'Private individual';
+
+$_LANG['fiIdentificationCompany'] = 'Company Registration Number';
+$_LANG['fiIdentificationPassport'] = 'Passport/ID number for Individuals';
+$_LANG['fiIdentificationSocialSecurityNumber'] = 'Social Security Number for Individuals';
+$_LANG['fiIdentificationBirthDate'] = 'Birthday for Foreign Private Individuals (YYYY-MM-DD)';

--- a/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
@@ -30,10 +30,19 @@ class ShoppingCartController
             $domainTlds = [];
             $fieldDisplay = '';
 
+            if (empty($vars['cart']['domains']) || !is_array($vars['cart']['domains'])) {
+                return '';
+            }
+
             foreach ($vars['cart']['domains'] as $domain) {
                 $mappedFields = [];
                 $domainName = $domain['domain'];
-                $fields = $domain['fields'];
+                $fields = $domain['fields'] ?? [];
+
+                if (!is_array($fields)) {
+                    continue;
+                }
+                
                 $tld = $this->getFullTld($domainName);
 
                 if (!$tld) {

--- a/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
@@ -214,8 +214,15 @@ class ShoppingCartController
             }
         }
 
-        $tld = explode('.', $domainName)[1];
-        return $tld;
+        $labels = array_values(array_filter(explode('.', $domainName), static function ($label) {
+            return $label !== '';
+        }));
+
+        if (empty($labels)) {
+            return '';
+        }
+
+        return (string) end($labels);
     }
 
     private function mapFieldsByIndex(array $fields, array $map): array

--- a/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
@@ -8,74 +8,116 @@ use idna_convert;
 
 class ShoppingCartController
 {
+    private static array $itFieldsMap = [
+        7 => 'companyRegistrationNumber',
+        9 => 'socialSecurityNumber',
+    ];
+
+    private static array $fiFieldsMap = [
+        1 => 'companyRegistrationNumber',
+        2 => 'passportNumber',
+        3 => 'socialSecurityNumber',
+        4 => 'birthDate',
+    ];
+
     public function checkoutOutput($vars)
     {
         global $_LANG;
+
         $idnumbermod = Configuration::get('idnumbermod');
         if ($idnumbermod) {
-            $domainsToMatch = ['es', 'pt'];
-            $data = []; // Initialize $data array
+            $data = [];
+            $domainTlds = [];
 
-            // Check if domains exist
-            if (!empty($vars['cart']['domains'])) {
-                foreach ($vars['cart']['domains'] as $domain) {
-                    $tld = explode('.', $domain['domain']);
-                    $f = 0;
-                    $fieldData = [];
+            foreach ($vars['cart']['domains'] as $domain) {
+                $domainName = $domain['domain'];
+                $fields = $domain['fields'];
+                $tld = $this->getFullTld($domainName);
 
-                    // Check if fields exist
-                    if (!empty($domain['fields']) && is_array($domain['fields'])) {
-                        foreach ($domain['fields'] as $field) {
-                            $f++;
-                            if (isset($tld[1]) && in_array($tld[1], $domainsToMatch)) {
-                                switch ($f) {
-                                    case 1:
-                                        $fieldData['field'] = $field;
-                                        break;
-                                    case 2:
-                                        $fieldData['value'] = $field;
-                                        break;
-                                }
-                            }
-                        }
-                    }
-
-                    if (!empty($fieldData)) {
-                        $data[$domain['domain']] = $fieldData;
-                    }
-                }
-            }
-
-            $fieldDisplay = ''; // Initialize $fieldDisplay
-
-            foreach ($data as $domain => $fields) {
-                if (empty($fields['field']) || empty($fields['value'])) {
+                if (!$tld) {
                     continue;
                 }
 
-                $name = '';
-                switch ($fields['field']) {
-                    case 'companyRegistrationNumber':
-                        $name = $_LANG['esIdentificationCompany'];
-                        break;
-                    case 'passportNumber':
-                        $name = $_LANG['esIdentificationPassport'];
-                        break;
-                    case 'vat':
-                        $name = $_LANG['ptIdentificationVat'];
-                        break;
-                    case 'socialSecurityNumber':
-                        $name = $_LANG['ptIdentificationSocialSecurityNumber'];
-                        break;
+                $domainTlds[$domainName] = $tld;
+                $fieldData = [];
+
+                if (in_array($tld, ['es', 'pt', 'se', 'com.es', 'nom.es', 'edu.es', 'org.es'])) {
+                    $f = 0;
+                    foreach ($fields as $field) {
+                        $f++;
+                        switch ($f) {
+                            case 1:
+                                $fieldData['field'] = $field;
+                                break;
+                            case 2:
+                                $fieldData['value'] = $field;
+                                break;
+                        }
+                    }
+                    if (!empty($fieldData['field']) && !empty($fieldData['value'])) {
+                        $data[$domainName] = [$fieldData];
+                    }
+                } elseif ($tld === 'it') {
+                    $mappedFields = $this->mapFieldsByIndex($fields, self::$itFieldsMap);
+                } elseif ($tld === 'fi') {
+                    $mappedFields = $this->mapFieldsByIndex($fields, self::$fiFieldsMap);
                 }
-
-                $fieldDisplay .= "<div class='col-sm-12'><div class='form-group prepend-icon'><label class='field-icon' for='" . $domain . "_" . $fields["field"] . "'> <i class='fas id-card'></i></label><input required class='form-control' readonly id='" . $domain . "_" . $fields["field"] . "' type='text' name='" . $fields["field"] . "' value='[$domain] $name:  " . $fields["value"] . "' /> </div></div>";
+                if (!empty($mappedFields)) {
+                    $data[$domainName] = $mappedFields;
+                }
             }
 
-            if (!empty($fieldDisplay)) {
-                $output = '<script type="text/javascript">$("#domainRegistrantInputFields").append("' . $fieldDisplay . '")</script>';
-                return $output;
+            foreach ($data as $domain => $fieldsArray) {
+                $tld = $domainTlds[$domain] ?? '';
+                if (isset($fieldsArray[0]) && is_array($fieldsArray[0])) {
+                    foreach ($fieldsArray as $fields) {
+                        $name = '';
+                        switch ($fields['field']) {
+                            case 'companyRegistrationNumber':
+                                if (in_array($tld, ['es', 'com.es', 'nom.es', 'edu.es', 'org.es'])) {
+                                    $name = $_LANG['esIdentificationCompany'];
+                                } elseif ($tld === 'se') {
+                                    $name = $_LANG['seIdentificationCompany'];
+                                } elseif ($tld === 'it') {
+                                    $name = $_LANG['itIdentificationCompany'];
+                                } elseif ($tld === 'fi') {
+                                    $name = $_LANG['fiIdentificationCompany'];
+                                }
+                                break;
+                            case 'passportNumber':
+                                if (in_array($tld, ['es', 'com.es', 'nom.es', 'edu.es', 'org.es'])) {
+                                    $name = $_LANG['esIdentificationPassport'];
+                                } elseif ($tld === 'fi') {
+                                    $name = $_LANG['fiIdentificationPassport'];
+                                }
+                                break;
+                            case 'vat':
+                                $name = $_LANG['ptIdentificationVat'];
+                                break;
+                            case 'socialSecurityNumber':
+                                if ($tld === 'pt') {
+                                    $name = $_LANG['ptIdentificationSocialSecurityNumber'];
+                                } elseif ($tld === 'se') {
+                                    $name = $_LANG['seIdentificationSocialSecurityNumber'];
+                                } elseif ($tld === 'it') {
+                                    $name = $_LANG['itIdentificationSocialSecurityNumber'];
+                                } elseif ($tld === 'fi') {
+                                    $name = $_LANG['fiIdentificationSocialSecurityNumber'];
+                                }
+                                break;
+                            case 'birthDate':
+                                $name = $_LANG['fiIdentificationBirthDate'];
+                                break;
+                        }
+
+                        $fieldDisplay .= "<div class='col-sm-12'><div class='form-group prepend-icon'><label class='field-icon' for='" . $domain . "_" . $fields["field"] . "'> <i class='fas id-card'></i></label><input required class='form-control' readonly id='" . $domain . "_" . $fields["field"] . "' type='text' name='" . $fields["field"] . "' value='[$domain] $name:  " . $fields["value"] . "' /> </div></div>";
+                    }
+                }
             }
+
+            $output = '<script type="text/javascript">$("#domainRegistrantInputFields").append(' . json_encode($fieldDisplay) . ')</script>';
+
+            return $output;
         }
 
         return ''; // Return empty string if no output
@@ -86,33 +128,33 @@ class ShoppingCartController
         $idnumbermod = Configuration::get('idnumbermod');
 
         if ($idnumbermod) {
-            $domainsToMatch = array('es', 'pt');
+
             $contactid      = $vars['contact'];
 
             foreach ($vars['domains'] as $domain) {
+                $domainName = $domain['domain'];
+                $fields = $domain['fields'];
+                $tld = $this->getFullTld($domainName);
 
-                $tld = explode('.', $domain['domain']);
+                if (!$tld || empty($fields) || empty($contactid)) {
+                    continue;
+                }
+                if (in_array($tld, ['es', 'pt', 'se', 'com.es', 'nom.es', 'edu.es', 'org.es'])) {
+                    $fieldsArray = array_values($fields);
+                    if (isset($fieldsArray[0]) && isset($fieldsArray[1])) {
+                        $fieldData = [
+                            'field' => $fieldsArray[0],
+                            'value' => $fieldsArray[1],
+                        ];
 
-                if (in_array($tld[1], $domainsToMatch)) {
-                    $fieldData = array();
-                    foreach ($domain['fields'] as $field) {
-                        if (
-                            $field == 'passportNumber' ||
-                            $field == 'companyRegistrationNumber' ||
-                            $field == 'vat' ||
-                            $field == 'socialSecurityNumber'
-                        ) {
-                            $fieldData['field'] = $field;
-                        }
-
-                        if (!empty($fieldData['field'])) {
-                            $fieldData['value'] = $field;
+                        if (!empty($fieldData['value']) && !empty($fieldData['field']) && !empty($contactid)) {
+                            DB::updateOrCreateContact($fieldData['value'], $contactid, $fieldData['field']);
                         }
                     }
-
-                    if (!empty($fieldData['value']) && !empty($fieldData['field']) && !empty($contactid)) {
-                        DB::updateOrCreateContact($fieldData['value'], $contactid, $fieldData['field']);
-                    }
+                } elseif ($tld === 'it') {
+                    $this->updateContactFields(self::$itFieldsMap, $fields, $contactid);
+                } elseif ($tld === 'fi') {
+                    $this->updateContactFields(self::$fiFieldsMap, $fields, $contactid);
                 }
             }
         }
@@ -160,5 +202,47 @@ class ShoppingCartController
         }
 
         return ['domains' => $updatedDomains];
+    }
+
+    private function getFullTld(string $domainName): string
+    {
+        $multiTlds = ['com.es', 'nom.es', 'edu.es', 'org.es'];
+
+        foreach ($multiTlds as $multiTld) {
+            if (str_ends_with($domainName, '.' . $multiTld)) {
+                return $multiTld;
+            }
+        }
+
+        $tld = explode('.', $domainName)[1];
+        return $tld;
+    }
+
+    private function mapFieldsByIndex(array $fields, array $map): array
+    {
+        $result = [];
+        foreach ($map as $index => $fieldName) {
+            if (!empty($fields[$index])) {
+                $result[] = [
+                    'field' => $fieldName,
+                    'value' => $fields[$index],
+                ];
+            }
+        }
+        return $result;
+    }
+
+    private function updateContactFields(array $map, array $fields, $contactId): void
+    {
+        foreach ($map as $index => $fieldName) {
+            if (!empty($fields[$index])) {
+                $fieldData = [
+                    'field' => $fieldName,
+                    'value' => $fields[$index],
+                ];
+
+                DB::updateOrCreateContact($fieldData['value'], $contactId, $fieldData['field']);
+            }
+        }
     }
 }

--- a/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
@@ -28,8 +28,10 @@ class ShoppingCartController
         if ($idnumbermod) {
             $data = [];
             $domainTlds = [];
+            $fieldDisplay = '';
 
             foreach ($vars['cart']['domains'] as $domain) {
+                $mappedFields = [];
                 $domainName = $domain['domain'];
                 $fields = $domain['fields'];
                 $tld = $this->getFullTld($domainName);

--- a/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ShoppingCartController.php
@@ -120,8 +120,11 @@ class ShoppingCartController
                                 $name = $_LANG['fiIdentificationBirthDate'];
                                 break;
                         }
+                        $fieldId = htmlspecialchars($domain . "_" . $fields["field"], ENT_QUOTES, 'UTF-8');
+                        $fieldName = htmlspecialchars($fields["field"], ENT_QUOTES, 'UTF-8');
+                        $fieldValue = htmlspecialchars("[$domain] $name: " . $fields["value"], ENT_QUOTES, 'UTF-8');
 
-                        $fieldDisplay .= "<div class='col-sm-12'><div class='form-group prepend-icon'><label class='field-icon' for='" . $domain . "_" . $fields["field"] . "'> <i class='fas id-card'></i></label><input required class='form-control' readonly id='" . $domain . "_" . $fields["field"] . "' type='text' name='" . $fields["field"] . "' value='[$domain] $name:  " . $fields["value"] . "' /> </div></div>";
+                        $fieldDisplay .= "<div class='col-sm-12'><div class='form-group prepend-icon'><label class='field-icon' for='" . $fieldId . "'> <i class='fas id-card'></i></label><input required class='form-control' readonly id='" . $fieldId . "' type='text' name='" . $fieldName . "' value='" . $fieldValue . "' /> </div></div>";
                     }
                 }
             }

--- a/modules/registrars/openprovider/configuration/advanced-module-configurations.php
+++ b/modules/registrars/openprovider/configuration/advanced-module-configurations.php
@@ -57,8 +57,8 @@ return [
     // maxRegistrationPeriod
     'maxRegistrationPeriod' => 1,
 
-    // enable advanced additional data management for .es and .pt domain registrations    
-    'idnumbermod' => false,
+    // enable advanced customer additional data management for .es, .pt, .se, .com.es, .nom.es, .edu.es, .org.es, .it and .fi domain registrations    
+    'idnumbermod' => true,
 
     'renewalDateSync' =>true, //  Default: true, If true, Set 'OP renewal date' to WHMCS as expiration date. Else Set 'OP expiration date' to WHMCS as expiration date.
 


### PR DESCRIPTION
- This PR contains the same changes as https://github.com/openprovider/Openprovider-WHMCS-domains/pull/386/.
- A new PR targeting master was created since the previous PR was already merged into version-6.0.0-stagging, and the current branch includes staging changes.

Changes: 
- Updated ShoppingCartCheckoutOutput hook to show customerAdditionalData for .se, .it, .fi, com.es, nom.es, edu.es, and org.es when creating a new contact during domain registration.
- Updated PreShoppingCartCheckout hook to store the customerAdditionalData for .es, .se, .it, .fi, com.es, nom.es, edu.es, and org.es when creating a new contact during domain registration.
- Updated /lang/overrides/english.php file.