### PR TITLE
INTGRTNS-500-Fix-external-nameserver-ip-resolution-in-createNameserversArray

### DIFF
--- a/modules/registrars/openprovider/OpenProvider/API/APITools.php
+++ b/modules/registrars/openprovider/OpenProvider/API/APITools.php
@@ -26,7 +26,7 @@ class APITools
         // }
 
         if ($params['test_mode'] == 'on' && $apiHelper != null) {
-            
+
             for ($i = 1; $i <= 5; $i++) {
                 $ns = $params["ns{$i}"];
                 if (!$ns) {
@@ -35,6 +35,16 @@ class APITools
                 $nsParts = explode('/', $ns);
                 $nsName = trim($nsParts[0]);
                 $nsIp = empty($nsParts[1]) ? null : trim($nsParts[1]);
+
+                // Glue records (NS is a child of the domain) require an IP.
+                // External nameservers must be accepted as-is without IP lookup.
+                $domainFqdn = strtolower($params['sld'] . '.' . $params['tld']);
+                $isGlue = str_ends_with(strtolower($nsName), '.' . $domainFqdn);
+
+                if (!$isGlue) {
+                    $nameServers[] = new \OpenProvider\API\DomainNameServer(['name' => $nsName]);
+                    continue;
+                }
 
                 //Try to get IP from searchNsRequest in REST API
                 if (empty($nsIp)) {
@@ -52,9 +62,12 @@ class APITools
                     $nsIp = gethostbyname($nsName);
                     if (!filter_var($nsIp, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
                         $nsIp = "";
-                        throw new \Exception("Invalid nameserver name: {$nsName}");
+                        throw new \Exception(
+                            "Could not resolve IP for glue record nameserver '{$nsName}'. "
+                                . "Please register it in OpenProvider before initiating the transfer."
+                        );
                     }
-                }                
+                }
 
                 if (!empty($nsIp) && !empty($nsName)) {
                     $nameServers[] = new \OpenProvider\API\DomainNameServer(array(
@@ -65,13 +78,13 @@ class APITools
             }
 
             if (count($nameServers) < 2) {
-                throw new \Exception('You must enter minimum 2 nameservers');
+                throw new \Exception('You must provide at least 2 nameservers.');
             }
 
             return $nameServers;
         }
 
-        $invalidNameServer = false;
+        $invalidGlueNameServers = [];
         for ($i = 1; $i <= 5; $i++) {
             $ns = $params["ns{$i}"];
             if (!$ns) {
@@ -81,6 +94,16 @@ class APITools
             $nsParts = explode('/', $ns);
             $nsName = trim($nsParts[0]);
             $nsIp = empty($nsParts[1]) ? null : trim($nsParts[1]);
+
+            // Glue records (NS is a child of the domain) require an IP.
+            // External nameservers must be accepted as-is without IP lookup.
+            $domainFqdn = strtolower($params['sld'] . '.' . $params['tld']);
+            $isGlue = str_ends_with(strtolower($nsName), '.' . $domainFqdn);
+
+            if (!$isGlue) {
+                $nameServers[] = new \OpenProvider\API\DomainNameServer(['name' => $nsName]);
+                continue;
+            }
 
             if (empty($nsIp)) {
                 $api = new \OpenProvider\API\API();
@@ -99,8 +122,8 @@ class APITools
                 $nsIp = gethostbyname($nsName);
                 if (!filter_var($nsIp, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
                     $nsIp = "";
-                    $invalidNameServer = true;
-                    logModuleCall('openprovider', 'createNameserversArray', $nsName, "Invalid nameserver name: {$nsName}", null, null);
+                    $invalidGlueNameServers[] = $nsName;
+                    logModuleCall('openprovider', 'createNameserversArray', $nsName, "Could not resolve IP for glue record nameserver: {$nsName}", null, null);
                 }
             }
 
@@ -113,11 +136,14 @@ class APITools
         }
 
         if (count($nameServers) < 2) {
-            if($invalidNameServer) {
-                throw new \Exception('You must enter minimum 2 nameservers. Invalid nameserver found. Please check the module log.');
-            }else{
-                throw new \Exception('You must enter minimum 2 nameservers');
-            }            
+            if (!empty($invalidGlueNameServers)) {
+                $names = implode(', ', $invalidGlueNameServers);
+                throw new \Exception(
+                    "Could not resolve IP for glue record nameserver(s): {$names}. "
+                        . "Please register them in OpenProvider before initiating the transfer."
+                );
+            }
+            throw new \Exception('You must provide at least 2 nameservers.');
         }
 
         return $nameServers;

--- a/modules/registrars/openprovider/OpenProvider/API/APITools.php
+++ b/modules/registrars/openprovider/OpenProvider/API/APITools.php
@@ -14,8 +14,9 @@ class APITools
     public static function createNameserversArray($params, $apiHelper = null)
     {
         $nameServers = array();
+        $domainFqdn = strtolower($params['sld'] . '.' . $params['tld']);
 
-        //can be used to hard-code a nameserver overwrite when using the DNS management addon 
+        //can be used to hard-code a nameserver overwrite when using the DNS management addon
         // if($params['dnsmanagement'] == true)
         // {
         //     $params['ns1'] = 'ns1.openprovider.nl';
@@ -38,7 +39,6 @@ class APITools
 
                 // Glue records (NS is a child of the domain) require an IP.
                 // External nameservers must be accepted as-is without IP lookup.
-                $domainFqdn = strtolower($params['sld'] . '.' . $params['tld']);
                 $isGlue = str_ends_with(strtolower($nsName), '.' . $domainFqdn);
 
                 if (!$isGlue) {
@@ -64,7 +64,7 @@ class APITools
                         $nsIp = "";
                         throw new \Exception(
                             "Could not resolve IP for glue record nameserver '{$nsName}'. "
-                                . "Please register it in OpenProvider before initiating the transfer."
+                                . "Please register it in OpenProvider before continuing."
                         );
                     }
                 }
@@ -97,7 +97,6 @@ class APITools
 
             // Glue records (NS is a child of the domain) require an IP.
             // External nameservers must be accepted as-is without IP lookup.
-            $domainFqdn = strtolower($params['sld'] . '.' . $params['tld']);
             $isGlue = str_ends_with(strtolower($nsName), '.' . $domainFqdn);
 
             if (!$isGlue) {
@@ -140,7 +139,7 @@ class APITools
                 $names = implode(', ', $invalidGlueNameServers);
                 throw new \Exception(
                     "Could not resolve IP for glue record nameserver(s): {$names}. "
-                        . "Please register them in OpenProvider before initiating the transfer."
+                        . "Please register them in OpenProvider before continuing."
                 );
             }
             throw new \Exception('You must provide at least 2 nameservers.');


### PR DESCRIPTION
## What this fixes

Closes #525.

`createNameserversArray()` was attempting to resolve an IP for every nameserver before including it in the request. For external nameservers (Cloudflare, Sectigo, OP's own NS, etc.) this is unnecessary — the OP API only requires a hostname for these. The IP lookup would silently drop any NS it couldn't resolve, causing operations to fail or proceed with an incomplete nameserver set.

## What changed

The function now checks whether each NS is a **glue record** (i.e. the NS hostname is a child of the domain being processed — `ns1.abc.com` for `abc.com`) before doing any IP resolution.

- **Glue records**: IP resolution is still performed — first from params, then `searchNsRequest`, then `gethostbyname()`. If no IP can be found, a clear exception is thrown.
- **External nameservers**: IP lookup is skipped entirely. Only the hostname is sent to the OP API.

Affects domain registration, transfer, and save nameservers — all three call this method.