### PR TITLE
Manage dns records directly from whmcs admin dashboard

### DIFF
--- a/modules/registrars/openprovider/Controllers/Hooks/ClientAreaPrimarySidebarController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ClientAreaPrimarySidebarController.php
@@ -23,10 +23,17 @@ class ClientAreaPrimarySidebarController
      * @var ApiHelper
      */
     private $apiHelper;
-
-    public function __construct(ApiHelper $apiHelper)
+    /**
+     * @var DNS
+     */
+    private $dnsHelper;
+    /**
+     * ConfigController constructor.
+     */
+    public function __construct(ApiHelper $apiHelper, DNS $dnsHelper)
     {
         $this->apiHelper = $apiHelper;
+        $this->dnsHelper = $dnsHelper;
     }
 
     public function show($primarySidebar)
@@ -52,7 +59,7 @@ class ClientAreaPrimarySidebarController
             return;
         }
 
-        if ($url = DNS::getDnsUrlOrFail($domainId)) {
+        if ($url = $this->dnsHelper->getDnsUrlOrFail($domainId)) {
             // Update the URL.
             $dnsManagement->setUri($url);
 

--- a/modules/registrars/openprovider/Controllers/Hooks/DnsAuthController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/DnsAuthController.php
@@ -13,9 +13,21 @@ use OpenProvider\WhmcsRegistrar\src\Configuration;
  */
 
 class DnsAuthController {
+    /**
+     * @var DNS
+     */
+    private $dnsHelper;
+    /**
+     * ConfigController constructor.
+     */
+    public function __construct(DNS $dnsHelper)
+    {
+        $this->dnsHelper = $dnsHelper;
+    }
+
     public function redirectDnsManagementPage($params)
     {
-        if ($url = DNS::getDnsUrlOrFail($params['domainid'])) {
+        if($url = $this->dnsHelper->getDnsUrlOrFail($params['domainid'])) {
 
             // Fallback if referer is not set or is not same-origin
             $defaultPreviousUrl = 'clientarea.php?action=domains';

--- a/modules/registrars/openprovider/Controllers/System/DnsController.php
+++ b/modules/registrars/openprovider/Controllers/System/DnsController.php
@@ -122,31 +122,58 @@ class DnsController extends BaseController
 
     public function redirectDnsManagementPage ($params)
     {
-        if($url = $this->dnsHelper->getDnsUrlOrFail($params['domainid'], true))
-        {
-            $urlOne = $_SERVER['HTTP_REFERER'];
-            $url_decoded = html_entity_decode($urlOne);
+        $url = $this->dnsHelper->getDnsUrlOrFail($params['domainid'], true);
 
-            // JavaScript confirm dialog
-            echo '<script type="text/javascript">
-                    document.addEventListener("DOMContentLoaded", function() {
-                        var userConfirmed = confirm("Do you want to open in New Tab?");
-                        if (userConfirmed) {
-                            var newWindow = window.open("' . $url . '", "_blank"); // Open OP DNS management page in a new tab
-                            if (newWindow) {
-                                window.location.href = "' . $url_decoded . '"; // Redirect to previous page
-                                newWindow.focus(); // Focus on the new tab
-                            } else {
-                                alert("New tab opening blocked! Please allow it for this site.");
-                                window.location.href = "' . $url . '"; // Redirect to OP DNS management page
-                            }
-                        } else {
-                            window.location.href = "' . $url . '"; // Redirect to OP DNS management page
-                        }
-                    });
-                  </script>';
-            exit;
+        if (!$url) {
+            return [
+                'error' => 'Unable to generate DNS Management URL.',
+            ];
         }
+
+        $previousUrl = isset($_SERVER['REQUEST_URI']) && $_SERVER['REQUEST_URI'] !== ''
+            ? $_SERVER['REQUEST_URI']
+            : '/';
+
+        if (isset($_SERVER['HTTP_REFERER']) && $_SERVER['HTTP_REFERER'] !== '') {
+            $referer = $_SERVER['HTTP_REFERER'];
+            $refererParts = parse_url($referer);
+
+            if (
+                is_array($refererParts) &&
+                isset($refererParts['host'], $_SERVER['HTTP_HOST']) &&
+                strtolower($refererParts['host']) === strtolower($_SERVER['HTTP_HOST'])
+            ) {
+                $previousUrl = $referer;
+            }
+        }
+
+        $encodedUrl = json_encode($url, JSON_UNESCAPED_SLASHES);
+        $encodedPreviousUrl = json_encode($previousUrl, JSON_UNESCAPED_SLASHES);
+
+        echo '<script type="text/javascript">
+                document.addEventListener("DOMContentLoaded", function() {
+                    var targetUrl = ' . $encodedUrl . ';
+                    var previousUrl = ' . $encodedPreviousUrl . ';
+
+                    var userConfirmed = confirm("Do you want to open in New Tab?");
+
+                    if (userConfirmed) {
+                        var newWindow = window.open(targetUrl, "_blank");
+
+                        if (newWindow) {
+                            window.location.href = previousUrl;
+                            newWindow.focus();
+                        } else {
+                            alert("New tab opening blocked! Please allow it for this site.");
+                            window.location.href = targetUrl;
+                        }
+                    } else {
+                        window.location.href = targetUrl;
+                    }
+                });
+            </script>';
+
+        exit;
     }
     
     private function isZoneNotFound(\Throwable $e): bool

--- a/modules/registrars/openprovider/Controllers/System/DnsController.php
+++ b/modules/registrars/openprovider/Controllers/System/DnsController.php
@@ -13,6 +13,7 @@ use OpenProvider\API\DNSrecord;
 use OpenProvider\API\Domain;
 use WeDevelopCoffee\wPower\Controllers\BaseController;
 use WeDevelopCoffee\wPower\Core\Core;
+use OpenProvider\WhmcsRegistrar\helpers\DNS;
 
 class DnsController extends BaseController
 {
@@ -26,16 +27,20 @@ class DnsController extends BaseController
      * @var ApiHelper
      */
     private $apiHelper;
-
+    /**
+     * @var DNS
+     */
+    private $dnsHelper;
     /**
      * ConfigController constructor.
      */
-    public function __construct(Core $core, Domain $domain, ApiHelper $apiHelper)
+    public function __construct(Core $core, Domain $domain, ApiHelper $apiHelper, DNS $dnsHelper)
     {
         parent::__construct($core);
 
         $this->domain = $domain;
         $this->apiHelper = $apiHelper;
+        $this->dnsHelper = $dnsHelper;
     }
 
     /**
@@ -115,6 +120,35 @@ class DnsController extends BaseController
         }
     }
 
+    public function redirectDnsManagementPage ($params)
+    {
+        if($url = $this->dnsHelper->getDnsUrlOrFail($params['domainid'], true))
+        {
+            $urlOne = $_SERVER['HTTP_REFERER'];
+            $url_decoded = html_entity_decode($urlOne);
+
+            // JavaScript confirm dialog
+            echo '<script type="text/javascript">
+                    document.addEventListener("DOMContentLoaded", function() {
+                        var userConfirmed = confirm("Do you want to open in New Tab?");
+                        if (userConfirmed) {
+                            var newWindow = window.open("' . $url . '", "_blank"); // Open OP DNS management page in a new tab
+                            if (newWindow) {
+                                window.location.href = "' . $url_decoded . '"; // Redirect to previous page
+                                newWindow.focus(); // Focus on the new tab
+                            } else {
+                                alert("New tab opening blocked! Please allow it for this site.");
+                                window.location.href = "' . $url . '"; // Redirect to OP DNS management page
+                            }
+                        } else {
+                            window.location.href = "' . $url . '"; // Redirect to OP DNS management page
+                        }
+                    });
+                  </script>';
+            exit;
+        }
+    }
+    
     private function isZoneNotFound(\Throwable $e): bool
     {
         if ((int) $e->getCode() === 872) {

--- a/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
+++ b/modules/registrars/openprovider/OpenProvider/API/ApiHelper.php
@@ -523,6 +523,22 @@ class ApiHelper
     }
 
     /**
+     * @param string $domain
+     * @param string $zone_provider
+     * @return array
+     * @throws \Exception 
+     */
+    public function getDnsDomainToken(string $domain, string $zone_provider): array
+    {
+        $args = [
+            'domain' => $domain,
+            'zone_provider' => $zone_provider,
+        ];
+
+        return $this->buildResponse($this->apiClient->call('createDomainTokenRequest', $args));
+    }
+
+    /**
      * @param string $handle
      * @param bool $formattedForWhmcs
      * @return array

--- a/modules/registrars/openprovider/OpenProvider/API/CommandMapping.php
+++ b/modules/registrars/openprovider/OpenProvider/API/CommandMapping.php
@@ -15,6 +15,7 @@ use Openprovider\Api\Rest\Client\Person\Api\PromoMessageServiceApi;
 use Openprovider\Api\Rest\Client\Person\Api\ResellerServiceApi;
 use Openprovider\Api\Rest\Client\Tld\Api\TldServiceApi;
 use Openprovider\Api\Rest\Client\Domain\Api\AuthCodeApi;
+use Openprovider\Api\Rest\Client\Dns\Api\DomainTokenApi;
 
 class CommandMapping
 {
@@ -133,6 +134,10 @@ class CommandMapping
         'deleteZoneDnsRequest' => [
             self::COMMAND_MAP_METHOD => 'createZone',
             self::COMMAND_MAP_CLASS => ZoneServiceApi::class,
+        ],
+        'createDomainTokenRequest' => [
+            self::COMMAND_MAP_METHOD => 'createToken',
+            self::COMMAND_MAP_CLASS => DomainTokenApi::class
         ],
 
         // Nameservers

--- a/modules/registrars/openprovider/openprovider.php
+++ b/modules/registrars/openprovider/openprovider.php
@@ -64,6 +64,7 @@ function openprovider_AdminCustomButtonArray()
     $buttonarray = array(
         "Auto-renew Sync" => "AutoRenewSync",
         "Sync" => "Sync",
+        "Manage DNS Zone" => "AdminManageDnsZone",
     );
 
     return $buttonarray;
@@ -340,6 +341,17 @@ function openprovider_ResendIRTPVerificationEmail(array $params)
 {
     // Perform API call to initiate resending of the IRTP Verification Email
     return openprovider_registrar_launch_decorator('resendIRTPVerificationEmail', $params);
+}
+
+/**
+ * Admin Manage Dns Zone
+ *
+ * @param array $params
+ * @return mixed
+ */
+function openprovider_AdminManageDnsZone($params)
+{
+    return openprovider_registrar_launch_decorator('adminManageDnsZone', $params);
 }
 
 

--- a/modules/registrars/openprovider/routes/system.php
+++ b/modules/registrars/openprovider/routes/system.php
@@ -32,6 +32,7 @@ return [
     // DNS
     'getDns'  => 'DnsController@get',
     'saveDns' => 'DnsController@save',
+    'adminManageDnsZone' => 'DnsController@redirectDnsManagementPage',
 
     // Contact
     'getContactDetails'  => 'ContactController@getDetails',


### PR DESCRIPTION
This PR contains the same changes as https://github.com/openprovider/Openprovider-WHMCS-domains/pull/425.

A new PR targeting `master` was created because the previous PR included Composer-related changes (`composer.json`, `composer.lock`, autoload files, and vendor folder updates) that were introduced as part of the `rest-client-php` library upgrade on the old branch.

Since `master` is now up to date with the required `rest-client-php` version, this new PR includes only the ticket-related changes and excludes those dependency and vendor file updates.

Changes: 
- Added new rest method getDnsDomainToken() in ApiHelper.
- Replaced legacy XML create token call with new REST based token flow.
- Refactored DNS helper to use REST API instead of deprecated XML API.
- Updated DNS controller to handle REST token redirect for Admin area.
- Updated client-side redirect logic to align with new REST Api flow.