### PR TITLE
Fix getMethodParamsTypes intermitent failure

### DIFF
--- a/modules/registrars/openprovider/OpenProvider/API/ParamsCreator.php
+++ b/modules/registrars/openprovider/OpenProvider/API/ParamsCreator.php
@@ -2,9 +2,7 @@
 
 namespace OpenProvider\API;
 
-use phpDocumentor\Reflection\DocBlockFactory;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
-use function GuzzleHttp\Psr7\_caseless_remove;
 
 class ParamsCreator
 {
@@ -188,14 +186,17 @@ class ParamsCreator
      * @param \ReflectionMethod $method
      * @return array
      */
-    private function getMethodParamsTypes(\ReflectionMethod $method)
+    private function getMethodParamsTypes(\ReflectionMethod $method): array
     {
-        $factory  = DocBlockFactory::createInstance();
-        $docblock = $factory->create($method->getDocComment());
+        $doc = $method->getDocComment();
+        if ($doc === false) {
+            return [];
+        }
+
         $paramTags = [];
-        foreach ($docblock->getTagsByName('param') as $tag) {
-            /** @var $tag \phpDocumentor\Reflection\DocBlock\Tags\Param */
-            $paramTags[$tag->getVariableName()] = (string)$tag->getType();
+        preg_match_all('/@param\s+(\S+)\s+\$(\w+)/', $doc, $matches, PREG_SET_ORDER);
+        foreach ($matches as $match) {
+            $paramTags[$match[2]] = explode('|', $match[1])[0];
         }
 
         return $paramTags;


### PR DESCRIPTION
## Problem

On some WHMCS servers, the daily cron aborts at `DomainTransferSync` with:

TypeError: PHPStan\PhpDocParser\Parser\TypeParser::__construct():
Argument #1 must be of type ?ConstExprParser, ParserConfig given



WHMCS core bundles `phpstan/phpdoc-parser` v0.4.14 and the OP module bundles v2.2.0. Both define `PHPStan\PhpDocParser\Parser\TypeParser` under the same namespace. When another component on the server (a module, addon, or hook) loads WHMCS's v0.4.14 `TypeParser` before the OP module initialises, it gets locked into PHP's class cache. The module's `DocBlockFactory::createInstance()` call then hits the v0.4.14 constructor with v2.2.0 arguments — fatal `TypeError`.

## Fix

Removed the `phpDocumentor\Reflection\DocBlockFactory` dependency from `ParamsCreator::getMethodParamsTypes()` and replaced it with a direct `preg_match_all` on the raw docblock string. The REST client only uses simple `@param string` / `@param int` types so the regex covers all cases and the `settype()` coercion behaviour is preserved.

## Files Changed

- `modules/registrars/openprovider/OpenProvider/API/ParamsCreator.php`