### PR TITLE
Update module version and add changelog for v5.12.1 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v5.12.1
+
+###### Features and improvements
+- Added German language support for registrar module.
+
+###### Bugfixes
+- Fixed: TypeError on DomainTransferSync cron due to phpstan namespace collision with WHMCS's bundled vendor.
+
 ## v5.12.0
 
 ###### Features and improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added German language support for registrar module.
 
 ###### Bugfixes
-- Fixed: TypeError on DomainTransferSync cron due to phpstan namespace collision with WHMCS's bundled vendor.
+- Fixed: TypeError on DomainTransferSync cron due to PHPStan namespace collision with WHMCS's bundled vendor.
 
 ## v5.12.0
 

--- a/modules/registrars/openprovider/OpenProvider/API/APIConfig.php
+++ b/modules/registrars/openprovider/OpenProvider/API/APIConfig.php
@@ -11,7 +11,7 @@ namespace OpenProvider\API;
 
 class APIConfig
 {
-    static public $moduleVersion     = 'whmcs-5.12.0-REST';
+    static public $moduleVersion     = 'whmcs-5.12.1-REST';
     static public $supportedDnsTypes = array('A', 'AAAA', 'CAA', 'CNAME', 'MX', 'SPF', 'SSHFP', 'SRV', 'TLSA', 'TXT');
     static public $dnsRecordTtl      = 86400;
     static public $dnsRecordPriority = 10;


### PR DESCRIPTION
This PR includes version number and changelog update for version 5.12.1 release. Here are the releasing PRs related to this release.

1. https://github.com/openprovider/Openprovider-WHMCS-domains/pull/547
2. https://github.com/openprovider/Openprovider-WHMCS-domains/pull/476
