### PR TITLE
Intgrtns 521 fix duplicate php tag appended to additionalfields.php during install

### DIFF
--- a/scripts/install_openprovider.sh
+++ b/scripts/install_openprovider.sh
@@ -127,11 +127,28 @@ if [ ! -f "$ADDITIONAL_FIELDS" ]; then
         exit 1
     fi
 else
-    echo "Updating existing additionalfields.php..."
-    grep -q 'openprovider_additional_fields' "$ADDITIONAL_FIELDS" || echo -e "<?php\nif (function_exists('openprovider_additional_fields'))\n    \$additionaldomainfields = openprovider_additional_fields();" >> "$ADDITIONAL_FIELDS"
-    if [ $? -ne 0 ]; then
-        echo "Error: Failed to update additionalfields.php. Check permissions."
-        exit 1
+    if ! grep -q 'openprovider_additional_fields' "$ADDITIONAL_FIELDS"; then
+        echo "Updating existing additionalfields.php..."
+        BACKUP_FILE="${ADDITIONAL_FIELDS}.$(date +%Y%m%d_%H%M%S).bak"
+        cp "$ADDITIONAL_FIELDS" "$BACKUP_FILE"
+        if [ $? -ne 0 ]; then
+            echo "Error: Failed to create backup of additionalfields.php. Check permissions."
+            exit 1
+        fi
+
+        printf '\nif (function_exists('\''openprovider_additional_fields'\''))\n    $additionaldomainfields = openprovider_additional_fields();\n' >> "$ADDITIONAL_FIELDS"
+        if [ $? -ne 0 ]; then
+            echo "Error: Failed to update additionalfields.php. Check permissions."
+            exit 1
+        fi
+
+        if ! php -l "$ADDITIONAL_FIELDS" > /dev/null 2>&1; then
+            echo "Error: additionalfields.php failed PHP syntax check after update. Restoring backup..."
+            cp "$BACKUP_FILE" "$ADDITIONAL_FIELDS"
+            exit 1
+        fi
+    else
+        echo "additionalfields.php already contains Openprovider configuration, skipping."
     fi
 fi
 

--- a/scripts/install_openprovider.sh
+++ b/scripts/install_openprovider.sh
@@ -136,7 +136,7 @@ else
             exit 1
         fi
 
-        printf '\nif (function_exists('\''openprovider_additional_fields'\''))\n    $additionaldomainfields = openprovider_additional_fields();\n' >> "$ADDITIONAL_FIELDS"
+        printf '\nif (function_exists('\''openprovider_additional_fields'\''))\n    $additionaldomainfields = openprovider_additional_fields() ?? [];\n' >> "$ADDITIONAL_FIELDS"
         if [ $? -ne 0 ]; then
             echo "Error: Failed to update additionalfields.php. Check permissions."
             exit 1

--- a/scripts/install_openprovider.sh
+++ b/scripts/install_openprovider.sh
@@ -136,16 +136,24 @@ else
             exit 1
         fi
 
+        if tail -c 100 "$ADDITIONAL_FIELDS" | grep -q '?>'; then
+            perl -i -0pe 's/\?>\s*$//' "$ADDITIONAL_FIELDS"
+        fi
+
         printf '\nif (function_exists('\''openprovider_additional_fields'\''))\n    $additionaldomainfields = openprovider_additional_fields() ?? [];\n' >> "$ADDITIONAL_FIELDS"
         if [ $? -ne 0 ]; then
             echo "Error: Failed to update additionalfields.php. Check permissions."
             exit 1
         fi
 
-        if ! php -l "$ADDITIONAL_FIELDS" > /dev/null 2>&1; then
-            echo "Error: additionalfields.php failed PHP syntax check after update. Restoring backup..."
-            cp "$BACKUP_FILE" "$ADDITIONAL_FIELDS"
-            exit 1
+       if command -v php > /dev/null 2>&1; then
+            if ! php -l "$ADDITIONAL_FIELDS" > /dev/null 2>&1; then
+                echo "Error: additionalfields.php failed PHP syntax check after update. Restoring backup..."
+                cp "$BACKUP_FILE" "$ADDITIONAL_FIELDS"
+                exit 1
+            fi
+        else
+            echo "Warning: PHP CLI not found in PATH. Skipping syntax check of additionalfields.php."
         fi
     else
         echo "additionalfields.php already contains Openprovider configuration, skipping."

--- a/scripts/install_openprovider.sh
+++ b/scripts/install_openprovider.sh
@@ -136,6 +136,12 @@ else
             exit 1
         fi
 
+        if ! grep -q '<?php' "$ADDITIONAL_FIELDS"; then
+            TMP_FILE=$(mktemp)
+            printf '<?php\n' | cat - "$ADDITIONAL_FIELDS" > "$TMP_FILE" && cp "$TMP_FILE" "$ADDITIONAL_FIELDS"
+            rm -f "$TMP_FILE"
+        fi
+
         if tail -c 100 "$ADDITIONAL_FIELDS" | grep -q '?>'; then
             perl -i -0pe 's/\?>\s*$//' "$ADDITIONAL_FIELDS"
         fi

--- a/scripts/update_openprovider.sh
+++ b/scripts/update_openprovider.sh
@@ -150,6 +150,12 @@ else
             exit 1
         fi
 
+        if ! grep -q '<?php' "$ADDITIONAL_FIELDS"; then
+            TMP_FILE=$(mktemp)
+            printf '<?php\n' | cat - "$ADDITIONAL_FIELDS" > "$TMP_FILE" && cp "$TMP_FILE" "$ADDITIONAL_FIELDS"
+            rm -f "$TMP_FILE"
+        fi
+
         if tail -c 100 "$ADDITIONAL_FIELDS" | grep -q '?>'; then
             perl -i -0pe 's/\?>\s*$//' "$ADDITIONAL_FIELDS"
         fi

--- a/scripts/update_openprovider.sh
+++ b/scripts/update_openprovider.sh
@@ -141,11 +141,36 @@ if [ ! -f "$ADDITIONAL_FIELDS" ]; then
         exit 1
     fi
 else
-    echo "Updating existing additionalfields.php..."
-    grep -q 'openprovider_additional_fields' "$ADDITIONAL_FIELDS" || echo -e "<?php\nif (function_exists('openprovider_additional_fields'))\n    \$additionaldomainfields = openprovider_additional_fields();" >> "$ADDITIONAL_FIELDS"
-    if [ $? -ne 0 ]; then
-        echo "Error: Failed to update additionalfields.php. Check permissions."
-        exit 1
+    if ! grep -q 'openprovider_additional_fields' "$ADDITIONAL_FIELDS"; then
+        echo "Updating existing additionalfields.php..."
+        BACKUP_FILE="${ADDITIONAL_FIELDS}.$(date +%Y%m%d_%H%M%S).bak"
+        cp "$ADDITIONAL_FIELDS" "$BACKUP_FILE"
+        if [ $? -ne 0 ]; then
+            echo "Error: Failed to create backup of additionalfields.php. Check permissions."
+            exit 1
+        fi
+
+        if tail -c 100 "$ADDITIONAL_FIELDS" | grep -q '?>'; then
+            perl -i -0pe 's/\?>\s*$//' "$ADDITIONAL_FIELDS"
+        fi
+
+        printf '\nif (function_exists('\''openprovider_additional_fields'\''))\n    $additionaldomainfields = openprovider_additional_fields() ?? [];\n' >> "$ADDITIONAL_FIELDS"
+        if [ $? -ne 0 ]; then
+            echo "Error: Failed to update additionalfields.php. Check permissions."
+            exit 1
+        fi
+
+        if command -v php > /dev/null 2>&1; then
+            if ! php -l "$ADDITIONAL_FIELDS" > /dev/null 2>&1; then
+                echo "Error: additionalfields.php failed PHP syntax check after update. Restoring backup..."
+                cp "$BACKUP_FILE" "$ADDITIONAL_FIELDS"
+                exit 1
+            fi
+        else
+            echo "Warning: PHP CLI not found in PATH. Skipping syntax check of additionalfields.php."
+        fi
+    else
+        echo "additionalfields.php already contains Openprovider configuration, skipping."
     fi
 fi
 


### PR DESCRIPTION
Summary
  - Removed duplicate <?php tag from the appended snippet — the root cause of the parse error on WHMCS 9.x installs
  - Added timestamped backup before modifying any existing file 
  - Added php -l validation after update with automatic backup restore on failure
  - Backup is only created when the file is actually modified — skipped on re-runs where OP content already exists
  - Added ?? [] null coalescing to the appended function call, consistent with the source additionalfields.php

  Tested and Verified Scenarios
  - Fresh install — file does not exist — copies cleanly, no backup
  - Vanilla WHMCS file — OP content appended without <?php, backup created, php -l passes
  - Re-run after install — "skipping" printed, no backup created, file unchanged
  - Third-party content (ISPAPI) — existing content preserved, OP appended, php -l passes
  - Syntax error in file — backup restored automatically, script exits with error