### PR TITLE
Fix: DNS management tab is getting disappeared once you navigate to DNSSEC management page

### DIFF
--- a/modules/registrars/openprovider/Controllers/System/DnssecPageController.php
+++ b/modules/registrars/openprovider/Controllers/System/DnssecPageController.php
@@ -77,6 +77,10 @@ class DnssecPageController extends BaseController
                 }
                 $openproviderNameserversCount++;
             }
+
+            $isSectigoDns = ($domainOp['hasActiveSectigoZone'] ?? false) === true
+                || ($domainOp['isSectigoDnsEnabled'] ?? false) === true
+                || str_contains(strtolower((string) ($domainOp['nsGroup'] ?? '')), 'sectigo');
         } catch (\Exception $e) {
             $this->redirectUserAway();
             return;
@@ -132,7 +136,7 @@ class DnssecPageController extends BaseController
             ->setUri("clientarea.php?action=domaincontacts&domainid={$domainId}")
             ->setOrder(40);
 
-        if ($openproviderNameserversCount > 1 && $domain->dnsmanagement) {
+        if (($openproviderNameserversCount > 1 || $isSectigoDns) && $domain->dnsmanagement) {
             $primarySidebar->getChild('Domain Details Management')
                 ->addChild('DNS Management')
                 ->setLabel(\Lang::trans('domaindnsmanagement'))


### PR DESCRIPTION
- The sidebar condition for showing the DNS Management tab only checked for OpenProvider nameservers, causing the tab to disappear for Sectigo nameserver domains on the DNSSEC page
- Added $isSectigoDns detection using `hasActiveSectigoZone`, `isSectigoDnsEnabled`, and `nsGroup` from `$domainOp`
- Updated condition to `($openproviderNameserversCount > 1 || $isSectigoDns) && $domain->dnsmanagement`