### PR TITLE
Add update or create handle related cutomer rows in DB in contact page

### DIFF
--- a/modules/registrars/openprovider/Controllers/System/ContactController.php
+++ b/modules/registrars/openprovider/Controllers/System/ContactController.php
@@ -257,6 +257,95 @@ class ContactController extends BaseController
         unset($contacts['Reseller']);
         unset($contacts['reseller']);
 
+        $this->syncHandlesWithWhmcs($params, $handlesToFetch, $contacts);
+
         return $contacts;
+    }
+
+    /**
+     * Sync wHandles and wDomain_handle for the fetched OP contact handles.
+     * Creates missing rows and updates the data field when it has changed.
+     */
+    private function syncHandlesWithWhmcs(array $params, array $handlesToFetch, array $contacts): void
+    {
+        try {
+            $domainName  = ($params['sld'] ?? '') . '.' . ($params['tld'] ?? '');
+            $whmcsDomain = Capsule::table('tbldomains')
+                ->where('domain', $domainName)
+                ->first(['id', 'userid']);
+
+            if (!$whmcsDomain) {
+                return;
+            }
+
+            $domainId = (int) $whmcsDomain->id;
+            $userId   = (int) $whmcsDomain->userid;
+
+            $roleToType = [
+                'Owner'   => 'registrant',
+                'Admin'   => 'admin',
+                'Tech'    => 'tech',
+                'Billing' => 'billing',
+            ];
+
+            foreach ($handlesToFetch as $roleName => $handleId) {
+                if (empty($handleId)) {
+                    continue;
+                }
+
+                $type = $roleToType[$roleName] ?? strtolower($roleName);
+
+                if (empty($contacts[$roleName])) {
+                    continue;
+                }
+
+                // Build a Customer object the same way prepareHandle does, using the contactdetails path
+                $customerParams = [
+                    'contactdetails' => [ucfirst($roleName) => $contacts[$roleName]],
+                ];
+                $row = Capsule::table('wHandles')
+                    ->where('handle', $handleId)
+                    ->where('user_id', $userId)
+                    ->where('registrar', 'openprovider')
+                    ->first();
+
+                if (!$row) {
+                    $customerObj = new \OpenProvider\API\Customer($customerParams, strtolower($roleName));
+                    $handleDbId  = Capsule::table('wHandles')->insertGetId([
+                        'handle'    => $handleId,
+                        'user_id'   => $userId,
+                        'registrar' => 'openprovider',
+                        'type'      => $type,
+                        'data'      => serialize($customerObj),
+                    ]);
+                } else {
+                    // Not overwriting data on an existing row — it may have been written by
+                    // prepareHandle with extensionAdditionalData set. Overwriting with our
+                    // partial Customer (extensionAdditionalData = null) would break findExisting's
+                    // exact-match lookup and cause duplicate handles on OP during register/transfer.
+                    $handleDbId = $row->id;
+                }
+
+                $existingLink = Capsule::table('wDomain_handle')
+                    ->where('domain_id', $domainId)
+                    ->where('type', $type)
+                    ->first();
+
+                if (!$existingLink) {
+                    Capsule::table('wDomain_handle')->insert([
+                        'domain_id' => $domainId,
+                        'handle_id' => $handleDbId,
+                        'type'      => $type,
+                    ]);
+                } elseif ((int) $existingLink->handle_id !== $handleDbId) {
+                    Capsule::table('wDomain_handle')
+                        ->where('domain_id', $domainId)
+                        ->where('type', $type)
+                        ->update(['handle_id' => $handleDbId]);
+                }
+            }
+        } catch (\Exception $e) {
+            logModuleCall('openprovider', 'syncHandlesWithWhmcs', $params, $e->getMessage());
+        }
     }
 }

--- a/modules/registrars/openprovider/Controllers/System/ContactController.php
+++ b/modules/registrars/openprovider/Controllers/System/ContactController.php
@@ -328,7 +328,7 @@ class ContactController extends BaseController
                 $this->syncDomainHandleLink($domainId, $handleDbIds[$handleId], $pivotType);
             }
         } catch (\Exception $e) {
-            logModuleCall('openprovider', 'syncHandlesWithWhmcs', $params, $e->getMessage());
+            logModuleCall('Openprovider NL', 'syncHandlesWithWhmcs', $params, $e->getMessage());
         }
     }
 

--- a/modules/registrars/openprovider/Controllers/System/ContactController.php
+++ b/modules/registrars/openprovider/Controllers/System/ContactController.php
@@ -264,8 +264,15 @@ class ContactController extends BaseController
 
     /**
      * Sync wHandles and wDomain_handle for the fetched OP contact handles.
-     * Creates missing rows and ensures wDomain_handle links exist.
-     * Note: does not overwrite wHandles.data for existing rows.
+     *
+     * wHandles.type rules:
+     *   - Owner is always type='all' (matches DomainController's findOrCreate default).
+     *   - Any OP handle shared by more than one role is also type='all', so findExisting
+     *     can locate it for any role search.
+     *   - A handle serving exactly one non-Owner role gets that role's specific type.
+     *
+     * wDomain_handle always uses the specific role type (registrant/admin/tech/billing).
+     * wHandles.data is never overwritten — existing rows may carry extensionAdditionalData.
      */
     private function syncHandlesWithWhmcs(array $params, array $handlesToFetch, array $contacts): void
     {
@@ -289,68 +296,127 @@ class ContactController extends BaseController
                 'Billing' => 'billing',
             ];
 
-            foreach ($handlesToFetch as $roleName => $handleId) {
-                if (empty($handleId)) {
-                    continue;
+            // Keep only roles that have both a handle ID and contact data.
+            $validRoles = array_filter($handlesToFetch, function ($handleId, $roleName) use ($contacts) {
+                return !empty($handleId) && !empty($contacts[$roleName]);
+            }, ARRAY_FILTER_USE_BOTH);
+
+            if (empty($validRoles)) {
+                return;
+            }
+
+            // How many roles each OP handle ID serves — used to decide wHandles.type.
+            $handleRoleCounts = array_count_values(array_values($validRoles));
+
+            $handleDbIds = [];
+            foreach ($validRoles as $roleName => $handleId) {
+                $pivotType = $roleToType[$roleName] ?? strtolower($roleName);
+
+                // Owner is always type='all' (matches DomainController's findOrCreate($params)
+                // default). Any handle shared by more than one role is also type='all' so
+                // findExisting can locate it regardless of which role type is searched.
+                $wHandleType = ($roleName === 'Owner' || $handleRoleCounts[$handleId] > 1)
+                    ? 'all'
+                    : $pivotType;
+
+                if (!isset($handleDbIds[$handleId])) {
+                    $handleDbIds[$handleId] = $this->ensureWHandleRow(
+                        $handleId, $userId, $wHandleType, $roleName, $contacts[$roleName]
+                    );
                 }
 
-                $type = $roleToType[$roleName] ?? strtolower($roleName);
-
-                if (empty($contacts[$roleName])) {
-                    continue;
-                }
-
-                // Build a Customer object the same way prepareHandle does, using the contactdetails path
-                $customerParams = [
-                    'contactdetails' => [ucfirst($roleName) => $contacts[$roleName]],
-                ];
-                $row = Capsule::table('wHandles')
-                    ->where('handle', $handleId)
-                    ->where('user_id', $userId)
-                    ->where('registrar', 'openprovider')
-                    ->first();
-
-                if (!$row) {
-                    $customerObj = new \OpenProvider\API\Customer($customerParams, strtolower($roleName));
-                    $handleDbId  = Capsule::table('wHandles')->insertGetId([
-                        'handle'     => $handleId,
-                        'user_id'    => $userId,
-                        'registrar'  => 'openprovider',
-                        'type'       => $type,
-                        'data'       => serialize($customerObj),
-                        'created_at' => date('Y-m-d H:i:s'),
-                        'updated_at' => date('Y-m-d H:i:s'),
-                    ]);
-                } else {
-                    // Not overwriting data on an existing row — it may have been written by
-                    // prepareHandle with extensionAdditionalData set. Overwriting with our
-                    // partial Customer (extensionAdditionalData = null) would break findExisting's
-                    // exact-match lookup and cause duplicate handles on OP during register/transfer.
-                    $handleDbId = $row->id;
-                }
-
-                $existingLink = Capsule::table('wDomain_handle')
-                    ->where('domain_id', $domainId)
-                    ->where('type', $type)
-                    ->first();
-
-                if (!$existingLink) {
-                    Capsule::table('wDomain_handle')->insert([
-                        'domain_id'  => $domainId,
-                        'handle_id'  => $handleDbId,
-                        'type'       => $type,
-                        'created_at' => date('Y-m-d H:i:s'),
-                        'updated_at' => date('Y-m-d H:i:s'),
-                    ]);
-                } elseif ((int) $existingLink->handle_id !== $handleDbId) {
-                    Capsule::table('wDomain_handle')
-                        ->where('domain_id', $domainId)
-                        ->where('type', $type)
-                        ->update(['handle_id' => $handleDbId, 'updated_at' => date('Y-m-d H:i:s')]);
-                }
+                $this->syncDomainHandleLink($domainId, $handleDbIds[$handleId], $pivotType);
             }
         } catch (\Exception $e) {
             logModuleCall('openprovider', 'syncHandlesWithWhmcs', $params, $e->getMessage());
+        }
+    }
+
+    /**
+     * Return the wHandles.id for the given OP handle, creating the row if absent.
+     * If the row exists with a different type, the type is corrected so findExisting
+     * can locate it for the right role. The data column is never overwritten — it may
+     * carry extensionAdditionalData set during register/transfer.
+     */
+    private function ensureWHandleRow(string $handleId, int $userId, string $type, string $roleName, array $contact): int
+    {
+        if ($type === 'all') {
+            // Prefer an existing 'all' row — if one already exists (e.g. created by
+            // findOrCreate during registration) use it directly. Only fall back to a
+            // specific-type row when no 'all' row exists, so we can upgrade it rather
+            // than creating a second row and leaving the first orphaned.
+            $row = Capsule::table('wHandles')
+                ->where('handle', $handleId)
+                ->where('user_id', $userId)
+                ->where('registrar', 'openprovider')
+                ->orderByRaw("CASE WHEN type = 'all' THEN 0 ELSE 1 END")
+                ->first();
+        } else {
+            // Same pattern as findExisting: match exact type OR 'all' in one query.
+            $row = Capsule::table('wHandles')
+                ->where('handle', $handleId)
+                ->where('user_id', $userId)
+                ->where('registrar', 'openprovider')
+                ->where(function ($q) use ($type) {
+                    $q->where('type', $type)->orWhere('type', 'all');
+                })
+                ->first();
+        }
+
+        if ($row) {
+            // Only upgrade to 'all' — never downgrade from 'all' to a specific type,
+            // and never change between specific types. Downgrading breaks findExisting
+            // for other roles that relied on the broader type.
+            if ($row->type !== 'all' && $type === 'all') {
+                Capsule::table('wHandles')
+                    ->where('id', $row->id)
+                    ->update(['type' => 'all', 'updated_at' => date('Y-m-d H:i:s')]);
+            }
+            return (int) $row->id;
+        }
+
+        $customerObj = new \OpenProvider\API\Customer(
+            ['contactdetails' => [ucfirst($roleName) => $contact]],
+            strtolower($roleName)
+        );
+        $now = date('Y-m-d H:i:s');
+
+        return (int) Capsule::table('wHandles')->insertGetId([
+            'handle'     => $handleId,
+            'user_id'    => $userId,
+            'registrar'  => 'openprovider',
+            'type'       => $type,
+            'data'       => serialize($customerObj),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    /**
+     * Ensure a wDomain_handle row exists for the given domain/type pointing to $handleDbId.
+     * Creates when missing; updates when it points to a different handle.
+     */
+    private function syncDomainHandleLink(int $domainId, int $handleDbId, string $type): void
+    {
+        $link = Capsule::table('wDomain_handle')
+            ->where('domain_id', $domainId)
+            ->where('type', $type)
+            ->first();
+
+        if (!$link) {
+            $now = date('Y-m-d H:i:s');
+            Capsule::table('wDomain_handle')->insert([
+                'domain_id'  => $domainId,
+                'handle_id'  => $handleDbId,
+                'type'       => $type,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        } elseif ((int) $link->handle_id !== $handleDbId) {
+            Capsule::table('wDomain_handle')
+                ->where('domain_id', $domainId)
+                ->where('type', $type)
+                ->update(['handle_id' => $handleDbId, 'updated_at' => date('Y-m-d H:i:s')]);
         }
     }
 }

--- a/modules/registrars/openprovider/Controllers/System/ContactController.php
+++ b/modules/registrars/openprovider/Controllers/System/ContactController.php
@@ -264,7 +264,8 @@ class ContactController extends BaseController
 
     /**
      * Sync wHandles and wDomain_handle for the fetched OP contact handles.
-     * Creates missing rows and updates the data field when it has changed.
+     * Creates missing rows and ensures wDomain_handle links exist.
+     * Note: does not overwrite wHandles.data for existing rows.
      */
     private function syncHandlesWithWhmcs(array $params, array $handlesToFetch, array $contacts): void
     {
@@ -312,11 +313,13 @@ class ContactController extends BaseController
                 if (!$row) {
                     $customerObj = new \OpenProvider\API\Customer($customerParams, strtolower($roleName));
                     $handleDbId  = Capsule::table('wHandles')->insertGetId([
-                        'handle'    => $handleId,
-                        'user_id'   => $userId,
-                        'registrar' => 'openprovider',
-                        'type'      => $type,
-                        'data'      => serialize($customerObj),
+                        'handle'     => $handleId,
+                        'user_id'    => $userId,
+                        'registrar'  => 'openprovider',
+                        'type'       => $type,
+                        'data'       => serialize($customerObj),
+                        'created_at' => date('Y-m-d H:i:s'),
+                        'updated_at' => date('Y-m-d H:i:s'),
                     ]);
                 } else {
                     // Not overwriting data on an existing row — it may have been written by
@@ -333,15 +336,17 @@ class ContactController extends BaseController
 
                 if (!$existingLink) {
                     Capsule::table('wDomain_handle')->insert([
-                        'domain_id' => $domainId,
-                        'handle_id' => $handleDbId,
-                        'type'      => $type,
+                        'domain_id'  => $domainId,
+                        'handle_id'  => $handleDbId,
+                        'type'       => $type,
+                        'created_at' => date('Y-m-d H:i:s'),
+                        'updated_at' => date('Y-m-d H:i:s'),
                     ]);
                 } elseif ((int) $existingLink->handle_id !== $handleDbId) {
                     Capsule::table('wDomain_handle')
                         ->where('domain_id', $domainId)
                         ->where('type', $type)
-                        ->update(['handle_id' => $handleDbId]);
+                        ->update(['handle_id' => $handleDbId, 'updated_at' => date('Y-m-d H:i:s')]);
                 }
             }
         } catch (\Exception $e) {

--- a/modules/registrars/openprovider/src/Handle.php
+++ b/modules/registrars/openprovider/src/Handle.php
@@ -171,6 +171,9 @@ class Handle
             $this->model    = $domain->handles()->wherePivot('type', $type)->firstOrFail();
             $currentHandleType = $this->model->type;
 
+            // Serialize the currently stored Customer before prepareHandle replaces it.
+            $storedData = serialize($this->model->data);
+
             // No domain found with this handle, let's continue
             $this->prepareHandle($params, $type);
 
@@ -178,6 +181,14 @@ class Handle
 
             if($action == false)
             {
+                // OP data matches the form, but wHandles.data may still be stale (e.g. written
+                // by syncHandlesWithWhmcs or an older flow). Update it so findExisting stays accurate.
+                $newData = serialize($this->customer);
+                if ($newData !== $storedData) {
+                    Capsule::table('wHandles')
+                        ->where('id', $this->model->id)
+                        ->update(['data' => $newData]);
+                }
                 return $this->model->handle;
             }
 

--- a/modules/registrars/openprovider/src/Handle.php
+++ b/modules/registrars/openprovider/src/Handle.php
@@ -171,18 +171,19 @@ class Handle
             $this->model    = $domain->handles()->wherePivot('type', $type)->firstOrFail();
             $currentHandleType = $this->model->type;
 
-            // Serialize the currently stored Customer before prepareHandle replaces it.
-            $storedData = serialize($this->model->data);
+            $storedData = Capsule::table('wHandles')
+                ->where('id', $this->model->id)
+                ->value('data') ?? '';
+
+            // Restore extensionAdditionalData / customerAdditionalData from the stored row
+            $this->restoreSpecialDataToHandle($storedData);
 
             // No domain found with this handle, let's continue
             $this->prepareHandle($params, $type);
 
             $action = $this->findChanges($params);
 
-            if($action == false)
-            {
-                // OP data matches the form, but wHandles.data may still be stale (e.g. written
-                // by syncHandlesWithWhmcs or an older flow). Update it so findExisting stays accurate.
+            if ($action == false) {
                 $newData = serialize($this->customer);
                 if ($newData !== $storedData) {
                     Capsule::table('wHandles')
@@ -440,5 +441,50 @@ class Handle
     {
         $this->apiHelper = $apiHelper;
         return $this;
+    }
+
+    /**
+     * Restore extensionAdditionalData / customerAdditionalData from the stored row
+     * onto the Handle object before prepareHandle is called. Only restores fields
+     * not already set by the caller (e.g. DomainController during registration).
+     */
+    private function restoreSpecialDataToHandle(string $storedData): void
+    {
+        $storedCustomer = @unserialize($storedData);
+
+        if (!is_object($storedCustomer)) {
+            return;
+        }
+
+        $extCount = is_array($storedCustomer->extensionAdditionalData)
+            ? count($storedCustomer->extensionAdditionalData)
+            : 0;
+
+        if (empty($this->extensionAdditionalData) && $extCount > 0) {
+            // Reconstruct fresh objects to avoid PHP 8.2 duplicate protected-property
+            // entries when re-serializing unserialized CustomerExtensionAdditionalData.
+            $rebuilt = [];
+            foreach ($storedCustomer->extensionAdditionalData as $storedExt) {
+                $ext     = new \OpenProvider\API\CustomerExtensionAdditionalData();
+                $payload = $storedExt->jsonSerialize();
+                if (!empty($payload['name'])) {
+                    $ext->setTld($payload['name']);
+                }
+                if (!empty($payload['data']) && is_array($payload['data'])) {
+                    foreach ($payload['data'] as $k => $v) {
+                        $ext->$k = $v;
+                    }
+                }
+                $rebuilt[] = $ext;
+            }
+            $this->setExtensionAdditionalData($rebuilt);
+        }
+
+        if (empty($this->customerAdditionalData) && is_object($storedCustomer->additionalData)) {
+            $storedFields = array_filter((array) $storedCustomer->additionalData);
+            if (!empty($storedFields)) {
+                $this->setCustomerAdditionalData($storedFields);
+            }
+        }
     }
 }

--- a/modules/registrars/openprovider/src/Handle.php
+++ b/modules/registrars/openprovider/src/Handle.php
@@ -187,7 +187,7 @@ class Handle
                 if ($newData !== $storedData) {
                     Capsule::table('wHandles')
                         ->where('id', $this->model->id)
-                        ->update(['data' => $newData]);
+                        ->update(['data' => $newData, 'updated_at' => date('Y-m-d H:i:s')]);
                 }
                 return $this->model->handle;
             }


### PR DESCRIPTION
### Root cause

When getContactDetails fetches domain contacts from the OP API, the wHandles and wDomain_handle tables were never populated for that domain. As a result, when the user submitted the WHOIS edit form, updateOrCreate in Handle.php could not find an existing handle in wHandles and fell through to create a new one in OP — duplicating the owner handle instead of updating it.

### Fix

Two files changed:

- ContactController.php — added syncHandlesWithWhmcs (+ two helpers) called after fetching contacts from the API in getContactDetails:

- Looks up the WHMCS domain and user from tbldomains

- For each role that has both a handle ID and contact data, ensures a wHandles row exists via ensureWHandleRow and a wDomain_handle pivot row via syncDomainHandleLink

- wHandles.type rules: Owner is always all; any OP handle shared by more than one role is also all; a handle serving exactly one non-Owner role gets that role's specific type (admin/tech/billing)

- Existing wHandles.data is never overwritten — it may carry extensionAdditionalData set during registration

- Type is upgrade-only (specific → all allowed; all → specific never)

Handle.php — in the updateOrCreate "no change" path (OP data matches the form, no API update needed): detects when wHandles.data is stale (e.g. written by the new sync with only basic contact fields) and refreshes it, keeping findExisting accurate on future calls.