### PR TITLE
Fix custom DNS management page redirect for non-Openprovider domains

### DIFF
--- a/modules/registrars/openprovider/Controllers/Hooks/ClientAreaPrimarySidebarController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ClientAreaPrimarySidebarController.php
@@ -52,12 +52,11 @@ class ClientAreaPrimarySidebarController
             return;
         }
 
-        $domain = Capsule::table('tbldomains')
-            ->where('id', $domainId)
-            ->select('registrar')
-            ->first();
+        $registrar = Capsule::table('tbldomains')
+            ->where('id', (int) $domainId)
+            ->value('registrar');
 
-        if (!$domain || $domain->registrar !== 'openprovider') {
+        if ((string) $registrar !== 'openprovider') {
             return;
         }
 

--- a/modules/registrars/openprovider/Controllers/Hooks/ClientAreaPrimarySidebarController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ClientAreaPrimarySidebarController.php
@@ -31,6 +31,19 @@ class ClientAreaPrimarySidebarController
 
     public function show($primarySidebar)
     {
+        $domainId = $_REQUEST['domainid'] ?? $_REQUEST['id'] ?? null;
+        if (!$domainId) {
+            return;
+        }
+
+        $registrar = Capsule::table('tbldomains')
+            ->where('id', (int) $domainId)
+            ->value('registrar');
+
+        if ((string) $registrar !== 'openprovider') {
+            return;
+        }
+
         $this->ensureDnsManagementPageExists();
 
         $this->replaceDnsMenuItem($primarySidebar);
@@ -49,14 +62,6 @@ class ClientAreaPrimarySidebarController
 
         $domainId = $_REQUEST['domainid'] ?? $_REQUEST['id'] ?? null;
         if (!$domainId) {
-            return;
-        }
-
-        $registrar = Capsule::table('tbldomains')
-            ->where('id', (int) $domainId)
-            ->value('registrar');
-
-        if ((string) $registrar !== 'openprovider') {
             return;
         }
 

--- a/modules/registrars/openprovider/Controllers/Hooks/ClientAreaPrimarySidebarController.php
+++ b/modules/registrars/openprovider/Controllers/Hooks/ClientAreaPrimarySidebarController.php
@@ -52,6 +52,15 @@ class ClientAreaPrimarySidebarController
             return;
         }
 
+        $domain = Capsule::table('tbldomains')
+            ->where('id', $domainId)
+            ->select('registrar')
+            ->first();
+
+        if (!$domain || $domain->registrar !== 'openprovider') {
+            return;
+        }
+
         if ($url = DNS::getDnsUrlOrFail($domainId)) {
             // Update the URL.
             $dnsManagement->setUri($url);


### PR DESCRIPTION
Added a registrar check to ensure the custom DNS management page redirect is only applied to openprovider domains.
