### PR TITLE
Fix Registrar / Addon Module Migration Execution Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.13.5
+
+###### Bugfixes
+- Fixed: Pending registrar and addon module migrations not executing correctly during activation and updates.
+
 ## v5.13.4
 
 ###### Features and improvements

--- a/modules/addons/openprovider/vendor/wedevelopcoffee/wpower/src/Module/Setup.php
+++ b/modules/addons/openprovider/vendor/wedevelopcoffee/wpower/src/Module/Setup.php
@@ -100,8 +100,25 @@ class Setup
         {
             foreach($this->migrationPaths as $path)
             {
-                if($action == 'run')
-                    $this->migrator->run($path);
+                if($action == 'run') {
+                    $files = $this->migrator->getMigrationFiles($path);
+
+                    $ran = $this->migrator->getRepository()->getRan();
+
+                    if ($ran instanceof \Illuminate\Support\Collection) {
+                        $ran = $ran->toArray();
+                    }
+
+                    $pending = \Illuminate\Support\Collection::make($files)
+                        ->reject(function ($file) use ($ran) {
+                            return in_array($this->migrator->getMigrationName($file), $ran, true);
+                        })
+                        ->values()
+                        ->all();
+
+                    $this->migrator->requireFiles($pending);
+                    $this->migrator->runPending($pending, []);
+                }
                 elseif($action == 'reset')
                 {
                     $files = $this->migrator->getMigrationFiles($path);

--- a/modules/registrars/openprovider/OpenProvider/API/APIConfig.php
+++ b/modules/registrars/openprovider/OpenProvider/API/APIConfig.php
@@ -11,7 +11,7 @@ namespace OpenProvider\API;
 
 class APIConfig
 {
-    static public $moduleVersion     = 'whmcs-5.13.4-REST';
+    static public $moduleVersion     = 'whmcs-5.13.5-REST';
     static public $supportedDnsTypes = array('A', 'AAAA', 'CAA', 'CNAME', 'MX', 'SPF', 'SSHFP', 'SRV', 'TLSA', 'TXT');
     static public $dnsRecordTtl      = 86400;
     static public $dnsRecordPriority = 10;

--- a/modules/registrars/openprovider/vendor/wedevelopcoffee/wpower/src/Module/Setup.php
+++ b/modules/registrars/openprovider/vendor/wedevelopcoffee/wpower/src/Module/Setup.php
@@ -100,8 +100,25 @@ class Setup
         {
             foreach($this->migrationPaths as $path)
             {
-                if($action == 'run')
-                    $this->migrator->run($path);
+                if($action == 'run') {
+                    $files = $this->migrator->getMigrationFiles($path);
+
+                    $ran = $this->migrator->getRepository()->getRan();
+
+                    if ($ran instanceof \Illuminate\Support\Collection) {
+                        $ran = $ran->toArray();
+                    }
+
+                    $pending = \Illuminate\Support\Collection::make($files)
+                        ->reject(function ($file) use ($ran) {
+                            return in_array($this->migrator->getMigrationName($file), $ran, true);
+                        })
+                        ->values()
+                        ->all();
+
+                    $this->migrator->requireFiles($pending);
+                    $this->migrator->runPending($pending, []);
+                }  
                 elseif($action == 'reset')
                 {
                     $files = $this->migrator->getMigrationFiles($path);


### PR DESCRIPTION
Updated wPower module migration execution to compute and run pending migrations explicitly, handling getRan() returning a Collection.
