### PR TITLE
Intgrtns 576 whmcs 9.0 upgrade openprovider dns management writes fail with session may have expired csrf token never populated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v5.13.7
+
+###### Bugfixes
+- Fixed: DNS Management save and delete operations failing in WHMCS 9.0.6 due to CSRF token conflicts.
+- Fixed: Sandbox API connection failures caused by the deprecated API endpoint.
+
 ## v5.13.6
 
 ###### Features and improvements

--- a/modules/registrars/openprovider/Controllers/System/DnsManagementPageController.php
+++ b/modules/registrars/openprovider/Controllers/System/DnsManagementPageController.php
@@ -19,6 +19,7 @@ class DnsManagementPageController extends BaseController
     const PAGE_TITLE = 'DNS Management';
     const PAGE_NAME  = 'DNS Management';
     const MODULE_NAME = 'dnsmanagement';
+    const CSRF_SESSION_KEY = 'opDnsManagementCsrfToken';
 
     /**
      * @var ApiHelper
@@ -79,10 +80,8 @@ class DnsManagementPageController extends BaseController
                 return;
             }
 
-            // WHMCS CSRF validation
-            try {
-                check_token('WHMCS.default', true); 
-            } catch (\Throwable $e) {
+            // CSRF validation
+            if (!$this->verifyCsrfToken()) {
                 http_response_code(403);
                 echo json_encode(['success' => false, 'error' => 'Invalid CSRF token']);
                 return;
@@ -156,10 +155,8 @@ class DnsManagementPageController extends BaseController
                 return;
             }
 
-            // CSRF
-            try {
-                check_token('WHMCS.default', true);
-            } catch (\Throwable $e) {
+            // CSRF validation
+            if (!$this->verifyCsrfToken()) {
                 http_response_code(403);
                 echo json_encode(['success' => false, 'error' => 'Invalid CSRF token']);
                 return;
@@ -286,8 +283,26 @@ class DnsManagementPageController extends BaseController
         }
 
         $ca->setTemplate($template);
-        $ca->assign('csrfToken', $_SESSION['token'] ?? \WHMCS\Session::get('token') ?? '');
+        // Deliberately NOT named 'csrfToken' — WHMCS's own ClientArea::output() appears to auto-populate/overwrite that variable name internally, which is what silently discarded our token.
+        $ca->assign('opDnsCsrfToken', $this->getCsrfToken());
         $ca->output();
+    }
+
+    private function getCsrfToken(): string
+    {
+        if (empty($_SESSION[self::CSRF_SESSION_KEY])) {
+            $_SESSION[self::CSRF_SESSION_KEY] = bin2hex(random_bytes(32));
+        }
+
+        return $_SESSION[self::CSRF_SESSION_KEY];
+    }
+
+    private function verifyCsrfToken(): bool
+    {
+        $submitted = (string) ($_POST['opDnsCsrfToken'] ?? '');
+
+        return !empty($_SESSION[self::CSRF_SESSION_KEY])
+            && hash_equals($_SESSION[self::CSRF_SESSION_KEY], $submitted);
     }
 
     private function buildDnsRecordsFromPost(): array

--- a/modules/registrars/openprovider/OpenProvider/API/APIConfig.php
+++ b/modules/registrars/openprovider/OpenProvider/API/APIConfig.php
@@ -11,7 +11,7 @@ namespace OpenProvider\API;
 
 class APIConfig
 {
-    static public $moduleVersion     = 'whmcs-5.13.6-REST';
+    static public $moduleVersion     = 'whmcs-5.13.7-REST';
     static public $supportedDnsTypes = array('A', 'AAAA', 'CAA', 'CNAME', 'MX', 'SPF', 'SSHFP', 'SRV', 'TLSA', 'TXT');
     static public $dnsRecordTtl      = 86400;
     static public $dnsRecordPriority = 10;

--- a/modules/registrars/openprovider/includes/templates/dnsmanagement.tpl
+++ b/modules/registrars/openprovider/includes/templates/dnsmanagement.tpl
@@ -15,7 +15,7 @@
         {else}
 
             <form id="opDnsForm" method="post" action="dnsmanagement.php?domainid={$domainId}">
-                <input type="hidden" name="token" value="{$csrfToken}" />
+                <input type="hidden" name="opDnsCsrfToken" value="{$opDnsCsrfToken}" />
                 <input type="hidden" name="sub" value="save" />
                 <input type="hidden" name="domainid" value="{$domainId}" />
 

--- a/modules/registrars/openprovider/includes/templates/dnsmanagement.tpl
+++ b/modules/registrars/openprovider/includes/templates/dnsmanagement.tpl
@@ -15,7 +15,7 @@
         {else}
 
             <form id="opDnsForm" method="post" action="dnsmanagement.php?domainid={$domainId}">
-                <input type="hidden" name="opDnsCsrfToken" value="{$opDnsCsrfToken}" />
+                <input type="hidden" name="opDnsCsrfToken" value="{$opDnsCsrfToken|escape:'html'}" />
                 <input type="hidden" name="sub" value="save" />
                 <input type="hidden" name="domainid" value="{$domainId}" />
 

--- a/modules/registrars/openprovider/includes/templates/js/modules/dnsmanagement.js
+++ b/modules/registrars/openprovider/includes/templates/js/modules/dnsmanagement.js
@@ -36,9 +36,9 @@ document.addEventListener('click', async function (e) {
   payload.set('address', btn.dataset.address || '');
   payload.set('priority', btn.dataset.priority || '');
 
-  // CSRF token: read ONLY from our DNS form 
-  const token = document.querySelector('#opDnsForm input[name="token"]')?.value;
-  if (token) payload.set('token', token);
+  // CSRF token: read ONLY from our DNS form
+  const token = document.querySelector('#opDnsForm input[name="opDnsCsrfToken"]')?.value || '';
+  payload.set('opDnsCsrfToken', token);
 
   btn.disabled = true;
 


### PR DESCRIPTION
- Replaced reliance on WHMCS's session CSRF `token`/`check_token() `with a self-contained, page-owned CSRF token (`DNSManagementPageController.php`).
- Renamed the CSRF field/variable from `token`/`csrfToken` to `opDnsCsrfToken` across the template, JS, and controller to avoid colliding with WHMCS's own reserved names (`dnsmanagement.tpl`, `dnsmanagement.js`).