### PR TITLE
INTGRTNS-579 - Fix: Domain Registrars page crashes when Openprovider credentials not configured

### DIFF
--- a/modules/registrars/openprovider/init.php
+++ b/modules/registrars/openprovider/init.php
@@ -91,6 +91,10 @@ function openprovider_bind_required_classes($launcher)
         $client = new ApiV1($logger, $camelCaseToSnakeCaseNameConverter, $idn);
         $client->getConfiguration()->setHost($host);
 
+        if (empty($params['Username']) || empty($params['Password'])) {
+            return $client;
+        }
+
         $tokenResult = null;
 
         if (Capsule::schema()->hasTable('reseller_tokens')) {

--- a/modules/registrars/openprovider/init.php
+++ b/modules/registrars/openprovider/init.php
@@ -91,15 +91,7 @@ function openprovider_bind_required_classes($launcher)
         $client = new ApiV1($logger, $camelCaseToSnakeCaseNameConverter, $idn);
         $client->getConfiguration()->setHost($host);
 
-        if (empty($params['Username']) || empty($params['Password'])) {
-            return $client;
-        }
-
-        $tokenResult = null;
-
-        if (Capsule::schema()->hasTable('reseller_tokens')) {
-            $tokenResult = Capsule::table('reseller_tokens')->where('username', $params['Username'])->orderBy('created_at', 'desc')->first();
-        } else {
+        if (!Capsule::schema()->hasTable('reseller_tokens')) {
             Capsule::schema()->create(
                 'reseller_tokens',
                 function ($table) {
@@ -112,6 +104,12 @@ function openprovider_bind_required_classes($launcher)
                 }
             );
         }
+
+        if (empty($params['Username']) || empty($params['Password'])) {
+            return $client;
+        }
+
+        $tokenResult = Capsule::table('reseller_tokens')->where('username', $params['Username'])->orderBy('created_at', 'desc')->first();
 
         $expireTime = $tokenResult ? new Carbon($tokenResult->expire_at) : false;
         $isAlive = $expireTime && Carbon::now()->diffInSeconds($expireTime, false) > 0;


### PR DESCRIPTION
Added a guard in `init.php` to skip the auth token request when openprovider username/password aren't configured yet. 

