### PR TITLE
Update additionalfields.php

### DIFF
--- a/modules/registrars/openprovider/configuration/additionalfields.php
+++ b/modules/registrars/openprovider/configuration/additionalfields.php
@@ -684,7 +684,7 @@ $additionaldomainfields[".se"][] = array(
 );
 
 $additionaldomainfields['.se'][] = array(
-    'Name' => 'Identification number',
+    'Name' => 'SE Identification number',
     "LangVar" => "seIdentificationNumber",
     "Type" => "text",
     "Size" => "30",


### PR DESCRIPTION
Changed 
'Name' => 'Identification number',
To
'Name' => 'SE Identification number',
Reason is to not be in conflict with the standard whmcs name for the fields, witch cause the number to not be stored.